### PR TITLE
Add dark mode and success screen

### DIFF
--- a/lib/flag_images.dart
+++ b/lib/flag_images.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+final Uint8List flagEs = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAADwAAAAoCAIAAAAt2Q6oAAAAVUlEQVR4nO3XwQkAIBDEQBX7b1l78BEJ'
+    'JBUM+zlunuFr/Qa8FJoqNFVoqtBUewhPonLp0FShqUJThaYKTRWaKjRVaKrQVEr0FP61zqVDU4WmCk2l'
+    'RF9ORANO3ev6PQAAAABJRU5ErkJggg==');
+
+final Uint8List flagCt = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAADwAAAAoCAIAAAAt2Q6oAAAAV0lEQVR4nO3V0QnAIBAFQQ3pv2XtIR8T'
+    'DnYqWA7x7bPmef4O+KJopWjlXQO/j5GXLlrZA5/0zEsXrRSttIhK0UqLqBStFK20iErRSouoFK0UrbSI'
+    'StHKBbewCE0xv/jvAAAAAElFTkSuQmCC');
+
+final Uint8List flagUk = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAADwAAAAoCAIAAAAt2Q6oAAAA1klEQVR4nNWYQRLCIBAEey3//+XxoGgS'
+    'yEUxRc+NA6HTVJYlFWYnAagaD2fkNvFZFyURQvtMJ/igARl0XlVDBQ1AlQg6n+LsgQZauZdAZ3cGSqCB'
+    'zalqgM6x1TBAA/vmZXnoTjMCaKDrEdeGHmlmdWhg1Irfz95mcn5YpZ8qMN2nLvE8OUrTSui/fYiH2/jU'
+    'SE1P/SMBJ2q/XiXpZztMHzwsDz3aouWhW7ayDdCdbAN0y1u2BHovWwLd8pTtgd7I9kC3JC7oJlsF3WKD'
+    'rsIHDSihq4TQ8AArMS5NSctvmwAAAABJRU5ErkJggg==');

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  final Locale locale;
+  AppLocalizations(this.locale);
+
+  /// Retrieve the localization instance from the closest [BuildContext].
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const supportedLocales = [
+    Locale('es'),
+    Locale('ca'),
+    Locale('en'),
+  ];
+
+  static const _localizedValues = <String, Map<String, String>>{
+    'es': {
+      'welcome': 'Bienvenido a Meypar Optima App',
+      'email': 'Email',
+      'password': 'Contraseña',
+      'signIn': 'Iniciar sesión',
+      'invalidEmail': 'La dirección de correo tiene un formato incorrecto.',
+      'userDisabled': 'La cuenta de usuario está desactivada.',
+      'userNotFound': 'No existe ningún usuario con ese correo.',
+      'wrongPassword': 'Correo o contraseña incorrectos.',
+      'tooManyRequests': 'Se han intentado demasiados accesos. Intenta más tarde.',
+      'invalidCredential': 'La credencial proporcionada es incorrecta o ha expirado.',
+      'loginError': 'Error al iniciar sesión: {error}',
+      'unexpectedError': 'Ha ocurrido un error inesperado.',
+      'zone': 'Zona',
+      'chooseZone': 'Escoge zona…',
+      'plate': 'Matrícula',
+      'plateRequired': 'La matrícula es obligatoria.',
+      'price': 'Precio',
+      'until': 'Hasta',
+      'pay': 'Pagar',
+      'correctPlate': '¿Es correcta la matrícula?',
+      'yes': 'Sí',
+      'no': 'No',
+      'sendTicketEmail': '¿Enviar ticket por email?',
+      'enterEmail': 'Introduce tu email',
+      'cancel': 'Cancelar',
+      'send': 'Enviar',
+      'ticketCreated': 'Ticket generado correctamente.',
+      'returningIn': 'Regresando en {seconds} s…',
+      'selectMethod': 'Selecciona el método de pago',
+      'cardPayment': 'Pago con tarjeta',
+      'qrPayment': 'Pago con QR',
+      'selectMethodError': 'Debes seleccionar un método antes de continuar.',
+      'processingPayment': 'Procesando pago…',
+      'paymentSuccess': 'Pago realizado con éxito',
+      'digitalTicket': 'Su ticket es digital.',
+      'paymentError': 'Error al procesar el pago',
+      'goHome': 'Volver a la pantalla principal',
+      'back': 'Atrás',
+    },
+    'ca': {
+      'welcome': 'Benvingut a Meypar Optima App',
+      'email': 'Email',
+      'password': 'Contrasenya',
+      'signIn': 'Iniciar sessió',
+      'invalidEmail': "L'adreça de correu té un format incorrecte.",
+      'userDisabled': 'El compte està desactivat.',
+      'userNotFound': 'No existeix cap usuari amb aquest correu.',
+      'wrongPassword': 'Correu o contrasenya incorrectes.',
+      'tooManyRequests': "S'han intentat massa accessos. Intenta més tard.",
+      'invalidCredential': 'La credencial és incorrecta o ha expirat.',
+      'loginError': 'Error en iniciar sessió: {error}',
+      'unexpectedError': 'Ha ocorregut un error inesperat.',
+      'zone': 'Zona',
+      'chooseZone': 'Escull zona…',
+      'plate': 'Matrícula',
+      'plateRequired': 'La matrícula és obligatòria.',
+      'price': 'Preu',
+      'until': 'Fins',
+      'pay': 'Pagar',
+      'correctPlate': 'És correcta la matrícula?',
+      'yes': 'Sí',
+      'no': 'No',
+      'sendTicketEmail': 'Enviar tiquet per email?',
+      'enterEmail': "Introdueix el teu email",
+      'cancel': 'Cancel·lar',
+      'send': 'Enviar',
+      'ticketCreated': 'Tiquet generat correctament.',
+      'returningIn': 'Tornant en {seconds} s…',
+      'selectMethod': 'Selecciona el mètode de pagament',
+      'cardPayment': 'Pagament amb targeta',
+      'qrPayment': 'Pagament amb QR',
+      'selectMethodError': 'Has de seleccionar un mètode abans de continuar.',
+      'processingPayment': 'Processant pagament…',
+      'paymentSuccess': 'Pagament completat',
+      'digitalTicket': 'El tiquet és digital.',
+      'paymentError': 'Error en processar el pagament',
+      'goHome': "Tornar a l'inici",
+      'back': 'Enrere',
+    },
+    'en': {
+      'welcome': 'Welcome to Meypar Optima App',
+      'email': 'Email',
+      'password': 'Password',
+      'signIn': 'Sign in',
+      'invalidEmail': 'The email address is badly formatted.',
+      'userDisabled': 'The user account is disabled.',
+      'userNotFound': 'There is no user with that email.',
+      'wrongPassword': 'Incorrect email or password.',
+      'tooManyRequests': 'Too many attempts. Try again later.',
+      'invalidCredential': 'The credential is invalid or has expired.',
+      'loginError': 'Error signing in: {error}',
+      'unexpectedError': 'An unexpected error occurred.',
+      'zone': 'Zone',
+      'chooseZone': 'Choose zone…',
+      'plate': 'Plate',
+      'plateRequired': 'Plate is required.',
+      'price': 'Price',
+      'until': 'Until',
+      'pay': 'Pay',
+      'correctPlate': 'Is the plate correct?',
+      'yes': 'Yes',
+      'no': 'No',
+      'sendTicketEmail': 'Send ticket by email?',
+      'enterEmail': 'Enter your email',
+      'cancel': 'Cancel',
+      'send': 'Send',
+      'ticketCreated': 'Ticket generated correctly.',
+      'returningIn': 'Returning in {seconds}s…',
+      'selectMethod': 'Select payment method',
+      'cardPayment': 'Card payment',
+      'qrPayment': 'QR payment',
+      'selectMethodError': 'Select a method before continuing.',
+      'processingPayment': 'Processing payment…',
+      'paymentSuccess': 'Payment completed successfully',
+      'digitalTicket': 'Your ticket is digital.',
+      'paymentError': 'Payment error',
+      'goHome': 'Return to main screen',
+      'back': 'Back',
+    },
+  };
+
+  String _get(String key) {
+    return _localizedValues[locale.languageCode]?[key] ??
+        _localizedValues['es']![key] ?? key;
+  }
+
+  String t(String key, {Map<String, String>? params}) {
+    var text = _get(key);
+    params?.forEach((k, v) {
+      text = text.replaceAll('{$k}', v);
+    });
+    return text;
+  }
+}
+
+class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) =>
+      ['es', 'ca', 'en'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(LocalizationsDelegate<AppLocalizations> old) => false;
+}

--- a/lib/language_selector.dart
+++ b/lib/language_selector.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'locale_provider.dart';
+import 'flag_images.dart';
+
+class LanguageSelector extends StatelessWidget {
+  const LanguageSelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = Provider.of<LocaleProvider>(context);
+    return Row(
+      children: [
+        _flagButton(context, prov, 'es', flagEs, 'ESP'),
+        const SizedBox(width: 8),
+        _flagButton(context, prov, 'ca', flagCt, 'CAT'),
+        const SizedBox(width: 8),
+        _flagButton(context, prov, 'en', flagUk, 'ENG'),
+      ],
+    );
+  }
+
+  Widget _flagButton(BuildContext context, LocaleProvider prov, String code, Uint8List bytes, String label) {
+    final selected = prov.locale.languageCode == code;
+    return InkWell(
+      onTap: () => prov.setLocale(Locale(code)),
+      borderRadius: BorderRadius.circular(8),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        padding: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected ? Theme.of(context).colorScheme.primary : Colors.transparent,
+            width: 2,
+          ),
+        ),
+        child: Column(
+          children: [
+            Image.memory(bytes, width: 32, height: 24),
+            Text(label, style: const TextStyle(fontSize: 10)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/locale_provider.dart
+++ b/lib/locale_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class LocaleProvider extends ChangeNotifier {
+  Locale _locale = const Locale('es');
+  Locale get locale => _locale;
+
+  void setLocale(Locale locale) {
+    if (locale == _locale) return;
+    _locale = locale;
+    notifyListeners();
+  }
+}

--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'l10n/app_localizations.dart';
+import 'language_selector.dart';
+import 'theme_mode_button.dart';
 
 /// Pantalla de login con email/contraseña, mensajes en español
 /// y estilo de botón/título actualizado.
@@ -34,31 +37,33 @@ class _LoginPageState extends State<LoginPage> {
       // TODO: Navegar a la pantalla principal
     } on FirebaseAuthException catch (e) {
       // Traducción de los códigos de error de FirebaseAuth
+      final l = AppLocalizations.of(context);
       switch (e.code) {
         case 'invalid-email':
-          _error = 'La dirección de correo tiene un formato incorrecto.';
+          _error = l.t('invalidEmail');
           break;
         case 'user-disabled':
-          _error = 'La cuenta de usuario está desactivada.';
+          _error = l.t('userDisabled');
           break;
         case 'user-not-found':
-          _error = 'No existe ningún usuario con ese correo.';
+          _error = l.t('userNotFound');
           break;
         case 'wrong-password':
-          _error = 'Correo o contraseña incorrectos.';
+          _error = l.t('wrongPassword');
           break;
         case 'too-many-requests':
-          _error = 'Se han intentado demasiados accesos. Intenta más tarde.';
+          _error = l.t('tooManyRequests');
           break;
         case 'invalid-credential':
-          _error = 'La credencial proporcionada es incorrecta o ha expirado.';
+          _error = l.t('invalidCredential');
           break;
         default:
-          _error = 'Error al iniciar sesión: ${e.message}';
+          _error = l.t('loginError', params: {'error': e.message ?? ''});
       }
     } catch (e) {
       // Cualquier otro error
-      _error = 'Ha ocurrido un error inesperado.';
+      final l = AppLocalizations.of(context);
+      _error = l.t('unexpectedError');
     } finally {
       setState(() => _loading = false);
     }
@@ -74,9 +79,20 @@ class _LoginPageState extends State<LoginPage> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
+              const Align(
+                alignment: Alignment.topRight,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    LanguageSelector(),
+                    SizedBox(width: 8),
+                    ThemeModeButton(),
+                  ],
+                ),
+              ),
               // Título de bienvenida
               Text(
-                'Bienvenido a Meypar Optima App',
+                AppLocalizations.of(context).t('welcome'),
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: const Color(0xFFE62144), // Rojo marca
@@ -89,11 +105,8 @@ class _LoginPageState extends State<LoginPage> {
               TextField(
                 controller: _emailCtrl,
                 decoration: InputDecoration(
-                  labelText: 'Email',
+                  labelText: AppLocalizations.of(context).t('email'),
                   prefixIcon: const Icon(Icons.email),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
                 ),
                 keyboardType: TextInputType.emailAddress,
               ),
@@ -103,11 +116,8 @@ class _LoginPageState extends State<LoginPage> {
               TextField(
                 controller: _passCtrl,
                 decoration: InputDecoration(
-                  labelText: 'Contraseña',
+                  labelText: AppLocalizations.of(context).t('password'),
                   prefixIcon: const Icon(Icons.lock),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
                 ),
                 obscureText: true,
               ),
@@ -137,13 +147,7 @@ class _LoginPageState extends State<LoginPage> {
                             strokeWidth: 2,
                           ),
                         )
-                      : const Text(
-                          'Iniciar sesión',
-                          style: TextStyle(
-                            color: Colors.white,         // Texto blanco
-                            fontWeight: FontWeight.bold,  // Negrita
-                          ),
-                        ),
+                      : Text(AppLocalizations.of(context).t('signIn')),
                 ),
               ),
             ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'firebase_options.dart';
 import 'login_page.dart';
 import 'home_page.dart';
+import 'l10n/app_localizations.dart';
+import 'locale_provider.dart';
+import 'theme_provider.dart';
+import 'theme_mode_button.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+  ]);
 
   try {
     // Espera hasta 10s a que Firebase init complete
@@ -28,36 +38,117 @@ class MyApp extends StatelessWidget {
   const MyApp({super.key});
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Kiosk App',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        primaryColor: const Color(0xFFE62144),
-        scaffoldBackgroundColor: Colors.white,
-        colorScheme: ColorScheme.fromSwatch().copyWith(
-          secondary: const Color(0xFF7F7F7F),
-          background: Colors.white,
-        ),
-        appBarTheme: const AppBarTheme(
-          backgroundColor: Color(0xFFE62144),
-          foregroundColor: Colors.white,
-          elevation: 0,
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: const Color(0xFFE62144),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => LocaleProvider()),
+        ChangeNotifierProvider(create: (_) => ThemeProvider()),
+      ],
+      child: Consumer2<LocaleProvider, ThemeProvider>(
+        builder: (context, localeProv, themeProv, _) {
+          return MaterialApp(
+            title: 'Kiosk App',
+            debugShowCheckedModeBanner: false,
+            locale: localeProv.locale,
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: const [
+              AppLocalizationsDelegate(),
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            theme: ThemeData(
+              useMaterial3: true,
+              primaryColor: const Color(0xFFE62144),
+              scaffoldBackgroundColor: Colors.white,
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: const Color(0xFFE62144),
+                secondary: const Color(0xFF7F7F7F),
+                background: Colors.white,
+              ),
+              appBarTheme: const AppBarTheme(
+                backgroundColor: Color(0xFFE62144),
+                foregroundColor: Colors.white,
+                elevation: 0,
+              ),
+              elevatedButtonTheme: ElevatedButtonThemeData(
+                style: ElevatedButton.styleFrom(
+                  minimumSize: const Size.fromHeight(60),
+                  backgroundColor: const Color(0xFFE62144),
+                  foregroundColor: Colors.white,
+                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+              ),
+              textButtonTheme: TextButtonThemeData(
+                style: TextButton.styleFrom(
+                  minimumSize: const Size.fromHeight(60),
+                  backgroundColor: const Color(0xFF7F7F7F),
+                  foregroundColor: Colors.white,
+                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+              ),
+              inputDecorationTheme: InputDecorationTheme(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                ),
+              ),
             ),
-          ),
-        ),
-        inputDecorationTheme: InputDecorationTheme(
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-        ),
+            darkTheme: ThemeData(
+              useMaterial3: true,
+              brightness: Brightness.dark,
+              scaffoldBackgroundColor: Colors.black,
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: const Color(0xFFE62144),
+                brightness: Brightness.dark,
+                secondary: const Color(0xFF7F7F7F),
+              ),
+              appBarTheme: const AppBarTheme(
+                backgroundColor: Color(0xFFE62144),
+                foregroundColor: Colors.white,
+                elevation: 0,
+              ),
+              elevatedButtonTheme: ElevatedButtonThemeData(
+                style: ElevatedButton.styleFrom(
+                  minimumSize: const Size.fromHeight(60),
+                  backgroundColor: const Color(0xFFE62144),
+                  foregroundColor: Colors.white,
+                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+              ),
+              textButtonTheme: TextButtonThemeData(
+                style: TextButton.styleFrom(
+                  minimumSize: const Size.fromHeight(60),
+                  backgroundColor: const Color(0xFF7F7F7F),
+                  foregroundColor: Colors.white,
+                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+              ),
+              inputDecorationTheme: InputDecorationTheme(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                ),
+              ),
+              textTheme: const TextTheme(
+                bodyLarge: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                bodyMedium: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+              ),
+            ),
+            themeMode: themeProv.mode,
+            home: const AuthGate(),
+          );
+        },
       ),
-      home: const AuthGate(),
     );
   }
 }

--- a/lib/payment_method_page.dart
+++ b/lib/payment_method_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'l10n/app_localizations.dart';
+import 'language_selector.dart';
+import 'theme_mode_button.dart';
+
+class PaymentMethodPage extends StatefulWidget {
+  final String zoneId;
+  final String plate;
+  final int duration;
+  final double price;
+  const PaymentMethodPage({
+    super.key,
+    required this.zoneId,
+    required this.plate,
+    required this.duration,
+    required this.price,
+  });
+
+  @override
+  State<PaymentMethodPage> createState() => _PaymentMethodPageState();
+}
+
+class _PaymentMethodPageState extends State<PaymentMethodPage> {
+  String? _selectedMethod;
+  bool _processing = false;
+  String? _message;
+
+  Future<void> _startPayment() async {
+    if (_selectedMethod == null) {
+      setState(() => _message = AppLocalizations.of(context).t('selectMethodError'));
+      return;
+    }
+    setState(() {
+      _processing = true;
+      _message = AppLocalizations.of(context).t('processingPayment');
+    });
+    await Future.delayed(const Duration(seconds: 2));
+    setState(() {
+      _processing = false;
+      _message = AppLocalizations.of(context).t('paymentSuccess');
+    });
+    await Future.delayed(const Duration(seconds: 2));
+    if (mounted) Navigator.pop(context, true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l.t('selectMethod')),
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        actions: const [LanguageSelector(), SizedBox(width: 8), ThemeModeButton()],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton.icon(
+              onPressed: () => setState(() => _selectedMethod = 'card'),
+              icon: const Icon(Icons.credit_card, size: 40),
+              label: Text(l.t('cardPayment')),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: _selectedMethod == 'card'
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.secondary,
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: () => setState(() => _selectedMethod = 'qr'),
+              icon: const Icon(Icons.qr_code_2, size: 40),
+              label: Text(l.t('qrPayment')),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: _selectedMethod == 'qr'
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.secondary,
+              ),
+            ),
+            const SizedBox(height: 32),
+            if (_message != null) ...[
+              Text(
+                _message!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+            ],
+            if (_processing)
+              const Center(child: CircularProgressIndicator()),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: _processing ? null : _startPayment,
+              child: Text(l.t('pay')),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/payment_success_page.dart
+++ b/lib/payment_success_page.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'l10n/app_localizations.dart';
+import 'language_selector.dart';
+import 'theme_mode_button.dart';
+
+class PaymentSuccessPage extends StatefulWidget {
+  final String ticketId;
+  const PaymentSuccessPage({super.key, required this.ticketId});
+
+  @override
+  State<PaymentSuccessPage> createState() => _PaymentSuccessPageState();
+}
+
+class _PaymentSuccessPageState extends State<PaymentSuccessPage> {
+  bool _askEmailDone = false;
+  int _seconds = 20;
+  Timer? _timer;
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _startCountdown() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (t) {
+      if (_seconds > 1) {
+        setState(() => _seconds--);
+      } else {
+        t.cancel();
+        Navigator.of(context).popUntil((r) => r.isFirst);
+      }
+    });
+  }
+
+  Future<void> _sendEmail() async {
+    final email = await _askForEmail();
+    if (email != null) await _launchEmail(email);
+    setState(() => _askEmailDone = true);
+    _startCountdown();
+  }
+
+  Future<String?> _askForEmail() async {
+    String email = '';
+    final l = AppLocalizations.of(context);
+    return showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        title: Text(l.t('enterEmail')),
+        content: TextField(
+          autofocus: true,
+          keyboardType: TextInputType.emailAddress,
+          decoration: const InputDecoration(hintText: 'correo@ejemplo.com'),
+          onChanged: (v) => email = v,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, null),
+            child: Text(l.t('cancel')),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              if (RegExp(r"^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$").hasMatch(email)) {
+                Navigator.pop(ctx, email);
+              }
+            },
+            child: Text(l.t('send')),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _launchEmail(String email) async {
+    final uri = Uri(
+      scheme: 'mailto',
+      path: email,
+      query: 'subject=Ticket Kiosk&body=Tu ticket: ${widget.ticketId}',
+    );
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l.t('paymentSuccess')),
+        automaticallyImplyLeading: false,
+        actions: const [LanguageSelector(), SizedBox(width: 8), ThemeModeButton()],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(l.t('digitalTicket'), textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+            Center(
+              child: QrImageView(
+                data: widget.ticketId,
+                version: QrVersions.auto,
+                size: 200,
+              ),
+            ),
+            const Spacer(),
+            if (!_askEmailDone) ...[
+              Text(l.t('sendTicketEmail'), textAlign: TextAlign.center),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      setState(() => _askEmailDone = true);
+                      _startCountdown();
+                    },
+                    child: Text(l.t('no')),
+                  ),
+                  ElevatedButton(
+                    onPressed: _sendEmail,
+                    child: Text(l.t('yes')),
+                  ),
+                ],
+              ),
+            ] else ...[
+              Text(
+                l.t('returningIn', params: {'seconds': '$_seconds'}),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).popUntil((r) => r.isFirst),
+                child: Text(l.t('goHome')),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/theme_mode_button.dart
+++ b/lib/theme_mode_button.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'theme_provider.dart';
+
+class ThemeModeButton extends StatelessWidget {
+  const ThemeModeButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = Provider.of<ThemeProvider>(context);
+    final isDark = prov.mode == ThemeMode.dark;
+    return IconButton(
+      icon: Icon(isDark ? Icons.light_mode : Icons.dark_mode),
+      onPressed: prov.toggle,
+    );
+  }
+}

--- a/lib/theme_provider.dart
+++ b/lib/theme_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeMode _mode = ThemeMode.light;
+  ThemeMode get mode => _mode;
+
+  void toggle() {
+    _mode = _mode == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # Iconos de Cupertino (iOS)
   cupertino_icons: ^1.0.8
@@ -22,7 +24,8 @@ dependencies:
   # Añadimos QR y envío de email
   qr_flutter: ^4.0.0         # Para generar código QR
   url_launcher: ^6.1.5       # Para abrir mailto: en el navegador o app
-  intl: ^0.19.0              # Formateo de fechas y monedas
+  intl: ^0.20.2              # Formateo de fechas y monedas
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:
@@ -31,3 +34,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/logo.png


### PR DESCRIPTION
## Summary
- add ThemeProvider and toggle button to switch dark/light mode
- show language flags with labels and highlight selection
- translate current date according to selected locale
- implement PaymentSuccessPage with QR and email option
- integrate dark mode and success flow across app

## Testing
- `dart format lib/l10n/app_localizations.dart lib/locale_provider.dart lib/language_selector.dart lib/payment_method_page.dart lib/login_page.dart lib/home_page.dart lib/main.dart lib/theme_provider.dart lib/theme_mode_button.dart lib/payment_success_page.dart >/tmp/format.log && tail -n 20 /tmp/format.log` *(fails: `dart: command not found`)*
- `flutter analyze >/tmp/analyze.log && tail -n 20 /tmp/analyze.log` *(fails: `flutter: command not found`)*
- `flutter test >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: `flutter: command not found`)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686d2599060083329981bb4de0a20231