### PR TITLE
Fix duration control logic and improve QR visibility

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -152,7 +152,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _increaseDuration() {
-    final next = _selectedDuration + _increment;
+    final next = _selectedDuration + 10;
     setState(() {
       _selectedDuration = next > _maxDuration ? _maxDuration : next;
       _updatePrice();
@@ -161,10 +161,9 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _decreaseDuration() {
-    final prev = _selectedDuration - _increment;
-    if (prev < _minDuration) return;
+    final prev = _selectedDuration - 10;
     setState(() {
-      _selectedDuration = prev;
+      _selectedDuration = prev < _minDuration ? _minDuration : prev;
       _updatePrice();
       _paidUntil = DateTime.now().add(Duration(minutes: _selectedDuration));
     });

--- a/lib/ticket_success_page.dart
+++ b/lib/ticket_success_page.dart
@@ -91,10 +91,18 @@ class _TicketSuccessPageState extends State<TicketSuccessPage> {
             const SizedBox(height: 16),
             Expanded(
               child: Center(
-                child: QrImageView(
-                  data: widget.ticketId,
-                  version: QrVersions.auto,
-                  size: 250,
+                child: Builder(
+                  builder: (context) {
+                    final isDark = Theme.of(context).brightness == Brightness.dark;
+                    return Container(
+                      color: isDark ? Colors.white : Colors.transparent,
+                      child: QrImageView(
+                        data: widget.ticketId,
+                        version: QrVersions.auto,
+                        size: 250,
+                      ),
+                    );
+                  },
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- adjust duration buttons to always change by 10 minutes
- ensure new duration updates price and paid-until time
- improve QR readability in dark mode by wrapping it with a white background

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e83f3c08c8332b2f60d3d05cbdfe8