### PR TITLE
Implement dynamic QR config and scanning

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -61,6 +61,11 @@ class AppLocalizations {
       'paymentError': 'Error al procesar el pago',
       'goHome': 'Volver a la pantalla principal',
       'back': 'Atrás',
+      'ticketDetails': 'Detalles del ticket',
+      'validUntil': 'Válido hasta',
+      'paymentMethod': 'Método de pago',
+      'status': 'Estado',
+      'ticketId': 'Ticket ID',
     },
     'ca': {
       'welcome': 'Benvingut a Meypar Optima App',
@@ -108,6 +113,11 @@ class AppLocalizations {
       'paymentError': 'Error en processar el pagament',
       'goHome': "Tornar a l'inici",
       'back': 'Enrere',
+      'ticketDetails': 'Detalls del tiquet',
+      'validUntil': 'Vàlid fins',
+      'paymentMethod': 'Mètode de pagament',
+      'status': 'Estat',
+      'ticketId': 'Identificador',
     },
     'en': {
       'welcome': 'Welcome to Meypar Optima App',
@@ -155,6 +165,11 @@ class AppLocalizations {
       'paymentError': 'Payment error',
       'goHome': 'Return to main screen',
       'back': 'Back',
+      'ticketDetails': 'Ticket details',
+      'validUntil': 'Valid until',
+      'paymentMethod': 'Payment method',
+      'status': 'Status',
+      'ticketId': 'Ticket ID',
     },
   };
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'l10n/app_localizations.dart';
 import 'locale_provider.dart';
 import 'theme_provider.dart';
 import 'theme_mode_button.dart';
+import 'qr_config_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -37,6 +38,7 @@ class MyApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (_) => LocaleProvider()),
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
+        ChangeNotifierProvider(create: (_) => QrConfig()),
       ],
       child: Consumer2<LocaleProvider, ThemeProvider>(
         builder: (context, localeProv, themeProv, _) {

--- a/lib/payment_method_page.dart
+++ b/lib/payment_method_page.dart
@@ -40,7 +40,7 @@ class _PaymentMethodPageState extends State<PaymentMethodPage> {
       _message = AppLocalizations.of(context).t('paymentSuccess');
     });
     await Future.delayed(const Duration(seconds: 2));
-    if (mounted) Navigator.pop(context, true);
+    if (mounted) Navigator.pop(context, _selectedMethod);
   }
 
   @override

--- a/lib/qr_config_provider.dart
+++ b/lib/qr_config_provider.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+/// TODO: Cambiar `qrFields` en Firestore (p. ej. añadir "price") y comprobar
+/// que la app muestra el nuevo dato sin recompilar.
+class QrConfig extends ChangeNotifier {
+  QrConfig() {
+    final doc = FirebaseFirestore.instance
+        .collection('settings')
+        .doc('qrConfig');
+    _sub = doc.snapshots().listen(_update);
+  }
+
+  late final StreamSubscription<DocumentSnapshot<Map<String, dynamic>>> _sub;
+  List<String> _qrFields = ['ticketId'];
+
+  List<String> get qrFields => List.unmodifiable(_qrFields);
+
+  void _update(DocumentSnapshot<Map<String, dynamic>> snap) {
+    final data = snap.data();
+    final fields = data?['qrFields'];
+    List<String> newFields = ['ticketId'];
+    if (fields is List) {
+      newFields = fields.whereType<String>().toList();
+      if (newFields.isEmpty) newFields = ['ticketId'];
+    }
+    if (!listEquals(newFields, _qrFields)) {
+      _qrFields = newFields;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub.cancel();
+    super.dispose();
+  }
+}

--- a/lib/ticket_details_page.dart
+++ b/lib/ticket_details_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'l10n/app_localizations.dart';
+
+class TicketDetailsPage extends StatelessWidget {
+  final Map<String, dynamic> data;
+  const TicketDetailsPage({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final scheme = Theme.of(context).colorScheme;
+    final status = data['status']?.toString();
+    Color? statusColor;
+    if (status == 'paid') {
+      statusColor = Colors.green;
+    } else if (status == 'cancelled') {
+      statusColor = Colors.red;
+    }
+    TextStyle valueStyle([Color? c]) =>
+        TextStyle(fontWeight: FontWeight.bold, color: c ?? scheme.onBackground);
+
+    Widget row(String label, String value, {Color? color}) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          children: [
+            Expanded(child: Text(label)),
+            Text(value, style: valueStyle(color)),
+          ],
+        ),
+      );
+    }
+
+    final widgets = <Widget>[];
+    void add(String field, String labelKey) {
+      final value = data[field];
+      if (value == null) return;
+      widgets.add(row(labelKey == 'status' ? l.t('status') : l.t(labelKey),
+          value.toString(),
+          color: field == 'status' ? statusColor : null));
+    }
+
+    add('ticketId', 'ticketId');
+    add('plate', 'plate');
+    add('zoneName', 'zone');
+    add('paidUntil', 'validUntil');
+    add('paymentMethod', 'paymentMethod');
+    add('status', 'status');
+    add('price', 'price');
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l.t('ticketDetails'))),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: widgets),
+      ),
+    );
+  }
+}

--- a/lib/ticket_scanner_page.dart
+++ b/lib/ticket_scanner_page.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'l10n/app_localizations.dart';
+import 'ticket_details_page.dart';
+
+class TicketScannerPage extends StatefulWidget {
+  const TicketScannerPage({super.key});
+
+  @override
+  State<TicketScannerPage> createState() => _TicketScannerPageState();
+}
+
+class _TicketScannerPageState extends State<TicketScannerPage> {
+  bool _processing = false;
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_processing) return;
+    final code = capture.barcodes.firstOrNull?.rawValue;
+    if (code == null) return;
+    try {
+      final map = jsonDecode(code) as Map<String, dynamic>;
+      _processing = true;
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (_) => TicketDetailsPage(data: map),
+        ),
+      );
+    } catch (_) {
+      // ignore invalid codes
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(l.t('scanQr'))),
+      body: MobileScanner(onDetect: _onDetect),
+    );
+  }
+}

--- a/lib/ticket_success_page.dart
+++ b/lib/ticket_success_page.dart
@@ -7,8 +7,8 @@ import 'language_selector.dart';
 import 'theme_mode_button.dart';
 
 class TicketSuccessPage extends StatefulWidget {
-  final String ticketId;
-  const TicketSuccessPage({super.key, required this.ticketId});
+  final String qrData;
+  const TicketSuccessPage({super.key, required this.qrData});
 
   @override
   State<TicketSuccessPage> createState() => _TicketSuccessPageState();
@@ -97,7 +97,7 @@ class _TicketSuccessPageState extends State<TicketSuccessPage> {
                     return Container(
                       color: isDark ? Colors.white : Colors.transparent,
                       child: QrImageView(
-                        data: widget.ticketId,
+                        data: widget.qrData,
                         version: QrVersions.auto,
                         size: 250,
                       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   url_launcher: ^6.1.5       # Para abrir mailto: en el navegador o app
   intl: ^0.20.2              # Formateo de fechas y monedas
   provider: ^6.1.2
+  mobile_scanner: ^5.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add QR configuration provider listening to Firestore
- save zone name and payment method when creating tickets
- build QR data from configurable fields
- show ticket details from scanned QR
- add scanner page using `mobile_scanner`
- wire new pages and provider in the app
- update translations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f98f7bb048332b777028738e2a8b7