### PR TITLE
Implement dynamic QR fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,29 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Configuración dinámica del QR
+
+La lista de campos que aparecen en el código QR **no está en el código**.
+Para modificarla accede a Firestore y edita el documento
+`settings/qrConfig`:
+
+1. Abre la consola de Firebase y navega a **Firestore**.
+2. Ve a la colección `settings` y abre el documento `qrConfig`.
+3. Edita el array `qrFields` para añadir, quitar o reordenar los nombres de
+   los campos del ticket que quieras mostrar.
+4. Guarda los cambios. La app leerá este array al generar cada QR y reflejará
+   la modificación sin desplegar una nueva versión.
+
+Ejemplo de valores para `qrFields`:
+
+```json
+["plate", "status"]
+```
+
+```json
+["plate", "paidUntil", "paymentMethod"]
+```
+
+**No modifiques el código para cambiar estos campos;** solamente actualiza el
+array `qrFields` en Firestore.


### PR DESCRIPTION
## Summary
- load `qrFields` from Firestore when showing the success page
- build QR code string dynamically from those fields
- document how to change the fields in Firestore

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686fafc326cc8332b70cf1601aaa6c88