### PR TITLE
Improve QR config lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Para modificarla accede a Firestore y edita el documento
 
 1. Abre la consola de Firebase y navega a **Firestore**.
 2. Ve a la colección `settings` y abre el documento `qrConfig`.
+   Asegúrate de escribirlo exactamente con esa mayúscula; el nombre es
+   sensible a mayúsculas y minúsculas.
 3. Edita el array `qrFields` para añadir, quitar o reordenar los nombres de
    los campos del ticket que quieras mostrar.
 4. Guarda los cambios. La app leerá este array al generar cada QR y reflejará

--- a/lib/ticket_success_page.dart
+++ b/lib/ticket_success_page.dart
@@ -33,10 +33,17 @@ class _TicketSuccessPageState extends State<TicketSuccessPage> {
     // Edita el array qrFields en Firestore (settings/qrConfig).
     try {
       final fs = FirebaseFirestore.instance;
-      final ticketDoc = await fs.collection('tickets').doc(widget.ticketId).get();
+      final ticketDoc =
+          await fs.collection('tickets').doc(widget.ticketId).get();
       final ticketData = ticketDoc.data() ?? {};
-      final configDoc =
-          await fs.collection('settings').doc('qrConfig').get();
+
+      final settings = fs.collection('settings');
+      var configDoc = await settings.doc('qrConfig').get();
+      if (!configDoc.exists) {
+        // Intentar alternativa en minúsculas por si el documento está mal nombrado
+        configDoc = await settings.doc('qrconfig').get();
+      }
+
       final fields = List<String>.from(configDoc.data()?['qrFields'] ?? []);
 
       final lines = <String>[];


### PR DESCRIPTION
## Summary
- allow lowercase `qrconfig` fallback
- clarify case sensitive document name in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb72a3f608332a3a4b3325d1ff515