### PR TITLE
Fix tariff listener path

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -99,7 +99,11 @@ class _HomePageState extends State<HomePage> {
 
   void _listenTariff(String zoneId) {
     _tariffSub?.cancel();
-    _tariffSub = _firestore.collection('tariffs').doc(zoneId).snapshots().listen(
+    _tariffSub = _firestore
+        .collection('tariffs')
+        .doc('tariff-$zoneId')
+        .snapshots()
+        .listen(
       (snap) {
         final data = snap.data();
         if (data == null) return;


### PR DESCRIPTION
## Summary
- adjust tariff listener to read from `tariff-<zoneId>`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc8afeba883328b959ac903b5dc7b