### PR TITLE
Extend ticket fields in pay service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ migrate_working_dir/
 .pub/
 /build/
 
+# Node related
+node_modules/
+
 # Symbolication related
 app.*.symbols
 

--- a/lib/pay_service.dart
+++ b/lib/pay_service.dart
@@ -3,10 +3,14 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 /// Función que crea un ticket en Firestore
-Future<void> payTicket({
+Future<String> payTicket({
   required String zoneId,
+  required String zoneName,
   required String plate,
   required int durationMinutes,
+  required double price,
+  required String paymentMethod,
+  required String userId,
 }) async {
   // Referencia a Firestore
   final firestore = FirebaseFirestore.instance;
@@ -16,11 +20,17 @@ Future<void> payTicket({
   final paidUntil = now.add(Duration(minutes: durationMinutes));
 
   // Creamos el documento en 'tickets'
-  await firestore.collection('tickets').add({
+  final doc = await firestore.collection('tickets').add({
     'zoneId': zoneId,
+    'zoneName': zoneName,
     'plate': plate,
     'paidUntil': Timestamp.fromDate(paidUntil),
     'status': 'paid',
     'duration': durationMinutes,
+    'price': price,
+    'paymentMethod': paymentMethod,
+    'userId': userId,
   });
+
+  return doc.id;
 }


### PR DESCRIPTION
## Summary
- add Node modules to gitignore
- implement payTicket with more ticket fields and return document id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870c7f24f608332a4d59fb6d37b3351