### PR TITLE
Extend ticket fields in pay service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ migrate_working_dir/
 .pub/
 /build/
 
+# Node related
+node_modules/
+
 # Symbolication related
 app.*.symbols
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ Ejemplo de valores para `qrFields`:
 
 **No modifiques el código para cambiar estos campos;** solamente actualiza el
 array `qrFields` en Firestore.
+
+## Ejecutar tests
+
+Para lanzar las pruebas automatizadas ejecuta:
+
+`npm test`
+

--- a/lib/pay_service.dart
+++ b/lib/pay_service.dart
@@ -3,24 +3,35 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 /// Función que crea un ticket en Firestore
-Future<void> payTicket({
+Future<String> payTicket({
   required String zoneId,
+  required String zoneName,
   required String plate,
   required int durationMinutes,
+  required double price,
+  required String paymentMethod,
+  required String userId,
+  FirebaseFirestore? firestore,
 }) async {
   // Referencia a Firestore
-  final firestore = FirebaseFirestore.instance;
+  final fs = firestore ?? FirebaseFirestore.instance;
 
   // Calculamos paidUntil
   final now = DateTime.now();
   final paidUntil = now.add(Duration(minutes: durationMinutes));
 
   // Creamos el documento en 'tickets'
-  await firestore.collection('tickets').add({
+  final doc = await fs.collection('tickets').add({
     'zoneId': zoneId,
+    'zoneName': zoneName,
     'plate': plate,
     'paidUntil': Timestamp.fromDate(paidUntil),
     'status': 'paid',
     'duration': durationMinutes,
+    'price': price,
+    'paymentMethod': paymentMethod,
+    'userId': userId,
   });
+
+  return doc.id;
 }

--- a/lib/ticket_success_page.dart
+++ b/lib/ticket_success_page.dart
@@ -9,7 +9,12 @@ import 'theme_mode_button.dart';
 
 class TicketSuccessPage extends StatefulWidget {
   final String ticketId;
-  const TicketSuccessPage({super.key, required this.ticketId});
+  final FirebaseFirestore firestore;
+  const TicketSuccessPage({
+    super.key,
+    required this.ticketId,
+    FirebaseFirestore? firestore,
+  }) : firestore = firestore ?? FirebaseFirestore.instance;
 
   @override
   State<TicketSuccessPage> createState() => _TicketSuccessPageState();
@@ -32,7 +37,7 @@ class _TicketSuccessPageState extends State<TicketSuccessPage> {
     // No modificar el código para cambiar los campos del QR.
     // Edita el array qrFields en Firestore (settings/qrConfig).
     try {
-      final fs = FirebaseFirestore.instance;
+      final fs = widget.firestore;
       final ticketDoc =
           await fs.collection('tickets').doc(widget.ticketId).get();
       final ticketData = ticketDoc.data() ?? {};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "flutter test"
   },
   "keywords": [],
   "author": "",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  fake_cloud_firestore: ^2.4.1
 
 flutter:
   uses-material-design: true

--- a/test/ticket_qr_test.dart
+++ b/test/ticket_qr_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+
+import 'package:kiosk_app/ticket_success_page.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+void main() {
+  testWidgets('TicketSuccessPage shows QR with all fields', (tester) async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('settings').doc('qrConfig').set({
+      'qrFields': [
+        'ticketId',
+        'plate',
+        'paidUntil',
+        'status',
+        'paymentMethod',
+        'zoneId'
+      ]
+    });
+
+    final paidUntil = DateTime(2025, 1, 1);
+    final ticketDoc = await firestore.collection('tickets').add({
+      'plate': '1234ABC',
+      'paidUntil': paidUntil,
+      'status': 'paid',
+      'paymentMethod': 'card',
+      'zoneId': 'centro',
+    });
+
+    await tester.pumpWidget(MaterialApp(
+      home: TicketSuccessPage(ticketId: ticketDoc.id, firestore: firestore),
+    ));
+
+    await tester.pumpAndSettle();
+
+    final qrWidget = tester.widget<QrImageView>(find.byType(QrImageView));
+    final qrData = qrWidget.data as String;
+    expect(qrData.split('\n').length, 6);
+    expect(qrData.contains('N/A'), isFalse);
+    expect(qrData.contains('1234ABC'), isTrue);
+    expect(qrData.contains('card'), isTrue);
+    expect(qrData.contains('centro'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add Node modules to gitignore
- implement payTicket with more ticket fields and return document id
- add test script for flutter
- enable firestore injection for testing and add an automated test

## Testing
- `npm test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c7f24f608332a4d59fb6d37b3351