### PR TITLE
Fix default price on homepage

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -46,7 +46,7 @@ class _HomePageState extends State<HomePage> {
   void initState() {
     super.initState();
     _loadZones();
-    _updatePrice();
+    // Price will remain at 0 until a zone is selected
     _paidUntil = DateTime.now().add(Duration(minutes: _selectedDuration));
 
     _clockTimer = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -130,6 +130,10 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _updatePrice() {
+    if (_selectedZoneId == null) {
+      _price = 0.0;
+      return;
+    }
     final blocks = (_selectedDuration / 10).ceil();
 
     double extraBlockPrice = 0.25; // por defecto
@@ -309,7 +313,6 @@ class _HomePageState extends State<HomePage> {
                         _selectedZoneId = v;
                         _selectedDuration = _minDuration;
                         _durationItems = [];
-                        _updatePrice();
                       });
                       if (v != null) _loadDurations(v);
                     },


### PR DESCRIPTION
## Summary
- ensure price stays at zero until a zone is selected
- remove price update before zone data loads

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719c933394833298b88004ddd45177