### PR TITLE
Add missing web plugin registrant

### DIFF
--- a/lib/web_plugin_registrant.dart
+++ b/lib/web_plugin_registrant.dart
@@ -1,0 +1,19 @@
+// Generated file. Do not edit.
+
+import 'package:cloud_firestore_web/cloud_firestore_web.dart';
+import 'package:firebase_auth_web/firebase_auth_web.dart';
+import 'package:firebase_core_web/firebase_core_web.dart';
+import 'package:cloud_functions_web/cloud_functions_web.dart';
+import 'package:url_launcher_web/url_launcher_web.dart';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+/// Registers Flutter web plugins.
+void registerPlugins(Registrar registrar) {
+  FirebaseCoreWeb.registerWith(registrar);
+  FirebaseAuthWeb.registerWith(registrar);
+  FirebaseFirestoreWeb.registerWith(registrar);
+  FirebaseFunctionsWeb.registerWith(registrar);
+  UrlLauncherPlugin.registerWith(registrar);
+  registrar.registerMessageHandler();
+}


### PR DESCRIPTION
## Summary
- add `lib/web_plugin_registrant.dart` with Flutter web plugin registrations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871a08d60cc8332b13c5bbb414a0c08