### PR TITLE
Add emergency countdown dialog

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -154,26 +154,38 @@ class _HomePageState extends State<HomePage> {
       context: context,
       barrierDismissible: false,
       builder: (context) {
-        _countdownTimer?.cancel();
-        _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-          setState(() {
-            _countdownSeconds--;
-          });
-          if (_countdownSeconds <= 0) {
-            timer.cancel();
-          }
-        });
-
         return StatefulBuilder(
           builder: (context, setStateDialog) {
+            _countdownTimer ??= Timer.periodic(const Duration(seconds: 1), (timer) {
+              if (_countdownSeconds > 0) {
+                setState(() => _countdownSeconds--);
+                setStateDialog(() {});
+              }
+              if (_countdownSeconds <= 0) {
+                timer.cancel();
+                _emergencyDialogVisible = false;
+                Navigator.of(context).pop();
+              }
+            });
+
             return AlertDialog(
-              title: const Text('Emergencia'),
+              title: Text(AppLocalizations.of(context).t('emergencyTitle')),
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(_emergencyReason),
+                  Text(
+                    AppLocalizations.of(context).t(
+                      'emergencyActiveLabel',
+                      params: {'reason': _emergencyReason},
+                    ),
+                  ),
                   const SizedBox(height: 16),
-                  Text('Cierre automático en $_countdownSeconds segundos'),
+                  Text(
+                    AppLocalizations.of(context).t(
+                      'autoCloseIn',
+                      params: {'seconds': '$_countdownSeconds'},
+                    ),
+                  ),
                 ],
               ),
               actions: [
@@ -183,7 +195,7 @@ class _HomePageState extends State<HomePage> {
                     _emergencyDialogVisible = false;
                     Navigator.of(context).pop();
                   },
-                  child: const Text('Cerrar'),
+                  child: Text(AppLocalizations.of(context).t('close')),
                 ),
               ],
             );
@@ -193,6 +205,7 @@ class _HomePageState extends State<HomePage> {
     ).then((_) {
       _emergencyDialogVisible = false;
       _countdownTimer?.cancel();
+      _countdownTimer = null;
     });
   }
 
@@ -485,7 +498,10 @@ class _HomePageState extends State<HomePage> {
                       margin: const EdgeInsets.only(bottom: 12),
                       color: Colors.red.shade300,
                       child: Text(
-                        _emergencyReason,
+                        AppLocalizations.of(context).t(
+                          'emergencyActiveLabel',
+                          params: {'reason': _emergencyReason},
+                        ),
                         style: const TextStyle(
                             color: Colors.white, fontWeight: FontWeight.bold),
                       ),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -61,6 +61,9 @@ class AppLocalizations {
       'paymentError': 'Error al procesar el pago',
       'goHome': 'Volver a la pantalla principal',
       'back': 'Atrás',
+      'emergencyTitle': 'Emergencia',
+      'autoCloseIn': 'Cierre automático en {seconds} s',
+      'emergencyActiveLabel': 'Emergencia: {reason}',
     },
     'ca': {
       'welcome': 'Benvingut a Meypar Optima App',
@@ -108,6 +111,9 @@ class AppLocalizations {
       'paymentError': 'Error en processar el pagament',
       'goHome': "Tornar a l'inici",
       'back': 'Enrere',
+      'emergencyTitle': 'Emergència',
+      'autoCloseIn': 'Tancament automàtic en {seconds} s',
+      'emergencyActiveLabel': 'Emergència: {reason}',
     },
     'en': {
       'welcome': 'Welcome to Meypar Optima App',
@@ -155,6 +161,9 @@ class AppLocalizations {
       'paymentError': 'Payment error',
       'goHome': 'Return to main screen',
       'back': 'Back',
+      'emergencyTitle': 'Emergency',
+      'autoCloseIn': 'Auto close in {seconds}s',
+      'emergencyActiveLabel': 'Emergency: {reason}',
     },
   };
 


### PR DESCRIPTION
## Summary
- show emergency warning dialog with 5s countdown
- localize emergency strings for ES/CA/EN
- display emergency notice above the form

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871c32ae0608332a257656c18d4f2d0