### PR TITLE
Update paidUntil overflow

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -269,21 +269,18 @@ class _HomePageState extends State<HomePage> {
 
     final paidUntil = now.add(Duration(minutes: _selectedDuration));
     if (paidUntil.isAfter(_endTime)) {
-      // Si sobrepasa el endTime, pasa al siguiente día válido y hora startTime
-      int daysToAdd = 1;
-      DateTime nextDay = now.add(Duration(days: daysToAdd));
+      // Si sobrepasa el endTime, avanza hasta el siguiente día válido
+      DateTime nextDay = paidUntil.add(const Duration(days: 1));
       while (!_validDays.contains(nextDay.weekday)) {
-        daysToAdd++;
-        nextDay = now.add(Duration(days: daysToAdd));
+        nextDay = nextDay.add(const Duration(days: 1));
       }
-      baseTime = DateTime(
+      return DateTime(
         nextDay.year,
         nextDay.month,
         nextDay.day,
         _startTime.hour,
         _startTime.minute,
       );
-      return baseTime;
     }
 
     return paidUntil;


### PR DESCRIPTION
## Summary
- ensure paidUntil skips to the next valid day instead of clamping to endTime

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871c8b1a8a8833296eeb9f7cc4f07a3