### PR TITLE
Fix icons without binary assets

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -543,7 +544,7 @@ class _HomePageState extends State<HomePage> {
                               _emergencyActive ? Colors.grey : const Color(0xFFE62144),
                           minimumSize: const Size(40, 40),
                         ),
-                        child: const Icon(Icons.remove, color: Colors.white),
+                        child: const Icon(CupertinoIcons.minus, color: Colors.white),
                       ),
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -562,7 +563,7 @@ class _HomePageState extends State<HomePage> {
                               _emergencyActive ? Colors.grey : const Color(0xFFE62144),
                           minimumSize: const Size(40, 40),
                         ),
-                        child: const Icon(Icons.add, color: Colors.white),
+                        child: const Icon(CupertinoIcons.add, color: Colors.white),
                       ),
                     ],
                   ),

--- a/lib/theme_mode_button.dart
+++ b/lib/theme_mode_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 import 'theme_provider.dart';
 
@@ -12,7 +13,7 @@ class ThemeModeButton extends StatelessWidget {
     return IconButton(
       iconSize: 32,
       color: Theme.of(context).colorScheme.primary,
-      icon: Icon(isDark ? Icons.light_mode : Icons.dark_mode),
+      icon: Icon(isDark ? CupertinoIcons.sun_max_fill : CupertinoIcons.moon_fill),
       onPressed: prov.toggle,
     );
   }


### PR DESCRIPTION
## Summary
- revert asset-based icons
- use Cupertino icons for duration and theme mode buttons

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871cb7b26d48332bbc1ea432ac66986