### PR TITLE
Modify emergency dialog UI

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -171,7 +171,11 @@ class _HomePageState extends State<HomePage> {
             });
 
             return AlertDialog(
-              title: Text(AppLocalizations.of(context).t('emergencyTitle')),
+              title: Text(
+                AppLocalizations.of(context).t('emergencyTitle'),
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -61,7 +61,7 @@ class AppLocalizations {
       'paymentError': 'Error al procesar el pago',
       'goHome': 'Volver a la pantalla principal',
       'back': 'Atrás',
-      'emergencyTitle': 'Emergencia',
+      'emergencyTitle': 'ADVERTENCIA',
       'autoCloseIn': 'Cierre automático en {seconds} s',
       'emergencyActiveLabel': 'Emergencia: {reason}',
     },


### PR DESCRIPTION
## Summary
- emphasize emergency dialog title
- tweak localization string for emergency dialog title

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874edc7410c83329e41ceb8a72f8223