### PR TITLE
Fix emergency reason localization

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -131,7 +131,8 @@ class _HomePageState extends State<HomePage> {
         _endTimeNextDay = _endTime.day != _startTime.day;
 
         _emergencyActive = (data['emergencyActive'] ?? false) as bool;
-        _emergencyReasonKey = (data['emergencyReasonKey'] ?? '') as String;
+        _emergencyReasonKey =
+            (data['emergencyReasonKey'] ?? '').toString();
 
         _validDays = List<int>.from(data['validDays'] ?? []);
 


### PR DESCRIPTION
## Summary
- ensure `emergencyReasonKey` from Firestore is always stored as a string

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874f06a9db88332b803cb411ee736aa