### PR TITLE
Fix emergency reason localization

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -131,7 +131,9 @@ class _HomePageState extends State<HomePage> {
         _endTimeNextDay = _endTime.day != _startTime.day;
 
         _emergencyActive = (data['emergencyActive'] ?? false) as bool;
-        _emergencyReasonKey = (data['emergencyReasonKey'] ?? '') as String;
+        final reasonField =
+            data['emergencyReasonKey'] ?? data['emergencyReason'];
+        _emergencyReasonKey = reasonField != null ? reasonField.toString() : '';
 
         _validDays = List<int>.from(data['validDays'] ?? []);
 


### PR DESCRIPTION
## Summary
- ensure emergency reason uses fallback to `emergencyReason` when `emergencyReasonKey` is absent

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6874f06a9db88332b803cb411ee736aa