### PR TITLE
Add Design1 page and localization

### DIFF
--- a/lib/design1_page.dart
+++ b/lib/design1_page.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:intl/intl.dart';
+
+import 'l10n/app_localizations.dart';
+import 'language_selector.dart';
+import 'theme_mode_button.dart';
+
+class Design1Page extends StatelessWidget {
+  const Design1Page({super.key});
+
+  static const Map<String, dynamic> _fallback = {
+    'title': 'Estacionamiento',
+    'fields': ['Seleccionar Zona', 'Matrícula', 'Duración'],
+    'dynamic_labels': ['Hora Actual', 'Hora de Finalización'],
+    'button': 'Pagar'
+  };
+
+  Future<Map<String, dynamic>> _loadData() async {
+    try {
+      final jsonStr =
+          await rootBundle.loadString('assets/design1/unnamed_metadata.json');
+      return jsonDecode(jsonStr) as Map<String, dynamic>;
+    } catch (_) {
+      return _fallback;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return FutureBuilder<Map<String, dynamic>>(
+      future: _loadData(),
+      builder: (context, snapshot) {
+        final data = snapshot.data ?? _fallback;
+        final fields = List<String>.from(data['fields'] ?? []);
+        final dyn = List<String>.from(data['dynamic_labels'] ?? []);
+
+        final now = DateTime.now();
+        final end = now.add(const Duration(hours: 1));
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(l.t('design1Title')),
+            leading: BackButton(onPressed: () => Navigator.pop(context)),
+            actions: const [
+              LanguageSelector(),
+              SizedBox(width: 8),
+              ThemeModeButton(),
+            ],
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (dyn.isNotEmpty)
+                  Text(
+                    '${l.t('currentTime')}: ${DateFormat.Hms().format(now)}',
+                  ),
+                const SizedBox(height: 8),
+                if (fields.isNotEmpty)
+                  TextField(
+                    decoration:
+                        InputDecoration(labelText: l.t('design1SelectZone')),
+                  ),
+                const SizedBox(height: 8),
+                if (fields.length > 1)
+                  TextField(
+                    decoration: InputDecoration(labelText: l.t('plate')),
+                  ),
+                const SizedBox(height: 8),
+                if (fields.length > 2)
+                  TextField(
+                    decoration: InputDecoration(labelText: l.t('duration')),
+                  ),
+                const SizedBox(height: 16),
+                if (dyn.length > 1)
+                  Text(
+                    '${l.t('finishTime')}: ${DateFormat.Hms().format(end)}',
+                  ),
+                const Spacer(),
+                ElevatedButton(
+                  onPressed: () {},
+                  child: Text(l.t('pay')),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -10,6 +10,7 @@ import 'language_selector.dart';
 import 'locale_provider.dart';
 import 'theme_mode_button.dart';
 import 'ticket_success_page.dart';
+import 'design1_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -644,6 +645,18 @@ class _HomePageState extends State<HomePage> {
                         : Text(
                             AppLocalizations.of(context).t('pay'),
                           ),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const Design1Page(),
+                        ),
+                      );
+                    },
+                    child: Text(AppLocalizations.of(context).t('design1')),
                   ),
                 ],
               ),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -64,6 +64,12 @@ class AppLocalizations {
       'emergencyTitle': 'ADVERTENCIA',
       'autoCloseIn': 'Cierre automático en {seconds} s',
       'emergencyActiveLabel': 'Emergencia: {reason}',
+      'design1': 'Dise\u00f1o 1',
+      'design1Title': 'Estacionamiento',
+      'design1SelectZone': 'Seleccionar Zona',
+      'duration': 'Duraci\u00f3n',
+      'currentTime': 'Hora Actual',
+      'finishTime': 'Hora de Finalizaci\u00f3n',
     },
     'ca': {
       'welcome': 'Benvingut a Meypar Optima App',
@@ -114,6 +120,12 @@ class AppLocalizations {
       'emergencyTitle': 'Emergència',
       'autoCloseIn': 'Tancament automàtic en {seconds} s',
       'emergencyActiveLabel': 'Emergència: {reason}',
+      'design1': 'Disseny 1',
+      'design1Title': 'Aparcament',
+      'design1SelectZone': 'Seleccionar Zona',
+      'duration': 'Durada',
+      'currentTime': 'Hora Actual',
+      'finishTime': 'Hora de Finalització',
     },
     'en': {
       'welcome': 'Welcome to Meypar Optima App',
@@ -164,6 +176,12 @@ class AppLocalizations {
       'emergencyTitle': 'Emergency',
       'autoCloseIn': 'Auto close in {seconds}s',
       'emergencyActiveLabel': 'Emergency: {reason}',
+      'design1': 'Design 1',
+      'design1Title': 'Parking',
+      'design1SelectZone': 'Select Zone',
+      'duration': 'Duration',
+      'currentTime': 'Current Time',
+      'finishTime': 'End Time',
     },
   };
 


### PR DESCRIPTION
## Summary
- add Design1Page to display a simple parking layout
- navigate to Design1Page from HomePage
- localize new text keys for Design1 screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fa6ae65c83329f78132dabbe76fd