### PR TITLE
Add Design1 page with Cupertino blur picker

### DIFF
--- a/lib/design1_page.dart
+++ b/lib/design1_page.dart
@@ -1,0 +1,56 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+
+import 'l10n/app_localizations.dart';
+
+class Design1Page extends StatefulWidget {
+  const Design1Page({super.key});
+
+  @override
+  State<Design1Page> createState() => _Design1PageState();
+}
+
+class _Design1PageState extends State<Design1Page> {
+  final List<int> durations = const [5, 10, 15, 20, 25, 30, 45, 60];
+  late int _minutes = durations.first;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        middle: Text(l.t('design1')),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                child: Container(
+                  width: 280,
+                  height: 180,
+                  color: CupertinoColors.systemGrey.withOpacity(0.25),
+                  child: CupertinoPicker(
+                    itemExtent: 40,
+                    onSelectedItemChanged: (i) {
+                      setState(() => _minutes = durations[i]);
+                    },
+                    children: durations
+                        .map((m) => Center(child: Text('$m ${l.t("min")}')))
+                        .toList(),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text('${l.t("selected")}: $_minutes'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -10,6 +11,7 @@ import 'language_selector.dart';
 import 'locale_provider.dart';
 import 'theme_mode_button.dart';
 import 'ticket_success_page.dart';
+import 'design1_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -626,6 +628,17 @@ class _HomePageState extends State<HomePage> {
                     ],
                   ),
                   const SizedBox(height: 24),
+                  CupertinoButton.filled(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        CupertinoPageRoute(
+                          builder: (_) => const Design1Page(),
+                        ),
+                      );
+                    },
+                    child: Text(AppLocalizations.of(context).t('design1')),
+                  ),
+                  const SizedBox(height: 16),
                   ElevatedButton(
                     onPressed: allReady ? _confirmAndPay : null,
                     style: ElevatedButton.styleFrom(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -64,6 +64,9 @@ class AppLocalizations {
       'emergencyTitle': 'ADVERTENCIA',
       'autoCloseIn': 'Cierre automático en {seconds} s',
       'emergencyActiveLabel': 'Emergencia: {reason}',
+      'design1': 'DISE\u00d1O 1',
+      'min': 'min',
+      'selected': 'Seleccionado',
     },
     'ca': {
       'welcome': 'Benvingut a Meypar Optima App',
@@ -114,6 +117,9 @@ class AppLocalizations {
       'emergencyTitle': 'Emergència',
       'autoCloseIn': 'Tancament automàtic en {seconds} s',
       'emergencyActiveLabel': 'Emergència: {reason}',
+      'design1': 'DISSENY 1',
+      'min': 'min',
+      'selected': 'Seleccionat',
     },
     'en': {
       'welcome': 'Welcome to Meypar Optima App',
@@ -164,6 +170,9 @@ class AppLocalizations {
       'emergencyTitle': 'Emergency',
       'autoCloseIn': 'Auto close in {seconds}s',
       'emergencyActiveLabel': 'Emergency: {reason}',
+      'design1': 'DESIGN 1',
+      'min': 'min',
+      'selected': 'Selected',
     },
   };
 

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "ca",
+  "design1": "DISSENY 1",
+  "min": "min",
+  "selected": "Seleccionat"
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "en",
+  "design1": "DESIGN 1",
+  "min": "min",
+  "selected": "Selected"
+}

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,0 +1,6 @@
+{
+  "@@locale": "es",
+  "design1": "DISE\u00d1O 1",
+  "min": "min",
+  "selected": "Seleccionado"
+}


### PR DESCRIPTION
## Summary
- add a Design1Page with blur picker UI
- expose Design1 navigation from HomePage using a `CupertinoButton.filled`
- localize new strings and create ARB files

## Testing
- `flutter` command unavailable
- `dart` command unavailable

------
https://chatgpt.com/codex/tasks/task_e_68750fef53cc8332a1256610968bc260