### PR TITLE
Implement sendTicketEmail

### DIFF
--- a/lib/email_service.dart
+++ b/lib/email_service.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+/// Sends ticket information by email using a Cloud Function.
+/// Returns `true` if the request was successful (status code 200),
+/// otherwise returns `false`.
+Future<bool> sendTicketEmail(String email, Map<String, dynamic> ticketData) async {
+  final url = Uri.parse('https://us-central1-optima-360-b055b.cloudfunctions.net/sendTicketEmail');
+  final response = await http.post(
+    url,
+    headers: {'Content-Type': 'application/json'},
+    body: jsonEncode({
+      'email': email,
+      'ticketData': ticketData,
+    }),
+  );
+
+  // Print body for debugging purposes
+  print('sendTicketEmail response: ${response.body}');
+
+  return response.statusCode == 200;
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -493,9 +493,22 @@ class _HomePageState extends State<HomePage> {
     _ticketId = doc.id;
     setState(() => _saving = false);
 
+    final dateFormat = DateFormat('dd-MMM-yyyy HH:mm', 'en_US');
+    final ticketData = {
+      'ticketId': _ticketId,
+      'plate': matricula,
+      'duration': _selectedDuration,
+      'paidUntil': dateFormat.format(paidUntil).toLowerCase(),
+      'price': _price,
+      'currentDateTime': dateFormat.format(now).toLowerCase(),
+    };
+
     await Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (_) => TicketSuccessPage(ticketId: _ticketId!),
+        builder: (_) => TicketSuccessPage(
+          ticketId: _ticketId!,
+          ticketData: ticketData,
+        ),
       ),
     );
 

--- a/lib/ticket_success_page.dart
+++ b/lib/ticket_success_page.dart
@@ -5,10 +5,16 @@ import 'package:qr_flutter/qr_flutter.dart';
 import 'l10n/app_localizations.dart';
 import 'language_selector.dart';
 import 'theme_mode_button.dart';
+import 'email_service.dart';
 
 class TicketSuccessPage extends StatefulWidget {
   final String ticketId;
-  const TicketSuccessPage({super.key, required this.ticketId});
+  final Map<String, dynamic> ticketData;
+  const TicketSuccessPage({
+    super.key,
+    required this.ticketId,
+    required this.ticketData,
+  });
 
   @override
   State<TicketSuccessPage> createState() => _TicketSuccessPageState();
@@ -50,6 +56,7 @@ class _TicketSuccessPageState extends State<TicketSuccessPage> {
     );
     if (!mounted) return;
     if (email != null) {
+      await sendTicketEmail(email, widget.ticketData);
       await showDialog(
         context: context,
         barrierDismissible: false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   url_launcher: ^6.1.5       # Para abrir mailto: en el navegador o app
   intl: ^0.20.2              # Formateo de fechas y monedas
   provider: ^6.1.2
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `sendTicketEmail` using http package
- use new function when requesting email after payment
- pass ticket data from `HomePage` to `TicketSuccessPage`
- include http package in `pubspec.yaml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878ef2e634883328e4ca120936a6985