### PR TITLE
Add cancel button on home page

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -508,6 +508,12 @@ class _HomePageState extends State<HomePage> {
     });
   }
 
+  void _refreshPage() {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const HomePage()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final allReady = !_saving &&
@@ -644,6 +650,11 @@ class _HomePageState extends State<HomePage> {
                         : Text(
                             AppLocalizations.of(context).t('pay'),
                           ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton(
+                    onPressed: _refreshPage,
+                    child: Text(AppLocalizations.of(context).t('cancel')),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- allow refreshing of home page
- add `Cancelar` button below the pay button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879039ed5088332b79086578365da01