### PR TITLE
Add TarifaSelector widget

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
@@ -10,6 +11,8 @@ import 'language_selector.dart';
 import 'locale_provider.dart';
 import 'theme_mode_button.dart';
 import 'ticket_success_page.dart';
+import 'tarifa_selector.dart';
+import 'package:http/http.dart' as http;
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -29,6 +32,8 @@ class _HomePageState extends State<HomePage> {
   int _minDuration = 0;
   int _maxDuration = 0;
   int _increment = 0;
+
+  List<Map<String, dynamic>> _rateSteps = [];
 
   double _price = 0.0;
   double _basePrice = 0.0;
@@ -159,6 +164,23 @@ class _HomePageState extends State<HomePage> {
         }
       });
     });
+  }
+
+  Future<void> _fetchRateSteps(String zoneId) async {
+    try {
+      final uri = Uri.parse('https://example.com/rateSteps?zone=$zoneId');
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data is List) {
+          setState(() {
+            _rateSteps = List<Map<String, dynamic>>.from(data);
+          });
+        }
+      }
+    } catch (_) {
+      // Ignorar errores de red por simplicidad
+    }
   }
 
   String _getEmergencyReason(BuildContext context) {
@@ -333,6 +355,22 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
+  void _onRateStepSelected(Map<String, dynamic> step) {
+    final durSeconds = step['durationInSeconds'] as int? ?? 0;
+    final priceCents = step['priceInCents'] as int? ?? 0;
+    final endStr = step['endDateTime'] as String? ?? '';
+    DateTime? endDt;
+    try {
+      endDt = DateTime.parse(endStr);
+    } catch (_) {}
+
+    setState(() {
+      _selectedDuration = durSeconds ~/ 60;
+      _price = priceCents / 100.0;
+      _paidUntil = endDt ?? _calculatePaidUntil(durSeconds ~/ 60);
+    });
+  }
+
   void _increaseDuration() {
     if (!_canIncreaseDuration) return;
 
@@ -415,9 +453,11 @@ class _HomePageState extends State<HomePage> {
       _emergencyActive = false;
       _emergencyReasonKey = '';
       _validDays = [];
+      _rateSteps = [];
     });
 
     _subscribeTariff(zoneId);
+    _fetchRateSteps(zoneId);
   }
 
   Future<void> _confirmAndPay() async {
@@ -612,6 +652,11 @@ class _HomePageState extends State<HomePage> {
                         child: const Icon(Icons.add, color: Colors.white),
                       ),
                     ],
+                  ),
+                  const SizedBox(height: 8),
+                  TarifaSelector(
+                    rateSteps: _rateSteps,
+                    onSelected: _onRateStepSelected,
                   ),
                   const SizedBox(height: 8),
                   Row(

--- a/lib/tarifa_selector.dart
+++ b/lib/tarifa_selector.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class TarifaSelector extends StatefulWidget {
+  final List<Map<String, dynamic>> rateSteps;
+  final ValueChanged<Map<String, dynamic>> onSelected;
+
+  const TarifaSelector({
+    Key? key,
+    required this.rateSteps,
+    required this.onSelected,
+  }) : super(key: key);
+
+  @override
+  State<TarifaSelector> createState() => _TarifaSelectorState();
+}
+
+class _TarifaSelectorState extends State<TarifaSelector> {
+  int? _selectedIndex;
+
+  @override
+  void didUpdateWidget(covariant TarifaSelector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.rateSteps != widget.rateSteps) {
+      _selectedIndex = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.rateSteps.isEmpty) {
+      return const Text(
+        'No hay tarifas disponibles',
+        style: TextStyle(color: Colors.grey),
+      );
+    }
+
+    return Wrap(
+      spacing: 8,
+      children: [
+        for (int i = 0; i < widget.rateSteps.length; i++)
+          _buildChip(i, widget.rateSteps[i]),
+      ],
+    );
+  }
+
+  Widget _buildChip(int index, Map<String, dynamic> step) {
+    final durationSeconds = step['durationInSeconds'] as int? ?? 0;
+    final priceCents = step['priceInCents'] as int? ?? 0;
+    final endDateTimeStr = step['endDateTime'] as String? ?? '';
+    final minutes = durationSeconds ~/ 60;
+    final price = priceCents / 100.0;
+    DateTime? endDateTime;
+    try {
+      endDateTime = DateTime.parse(endDateTimeStr);
+    } catch (_) {}
+    final formattedHour = endDateTime != null
+        ? '${endDateTime.hour.toString().padLeft(2, '0')}:${endDateTime.minute.toString().padLeft(2, '0')}'
+        : '--:--';
+    final label = '$minutes min - ${price.toStringAsFixed(2)} € - Hasta $formattedHour';
+
+    return ChoiceChip(
+      label: Text(label),
+      selected: _selectedIndex == index,
+      onSelected: (_) {
+        setState(() => _selectedIndex = index);
+        widget.onSelected(step);
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   url_launcher: ^6.1.5       # Para abrir mailto: en el navegador o app
   intl: ^0.20.2              # Formateo de fechas y monedas
   provider: ^6.1.2
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create `TarifaSelector` widget for selecting rate steps
- integrate tariff selector into `HomePage`
- fetch rate steps from API when zone is selected
- update selected duration and price when a step is chosen
- add `http` dependency
- show TarifaSelector even if there are no rate steps

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a32522e348332a91e0651303db50f