### PR TITLE
Add MOWIZ button and page

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -10,6 +10,7 @@ import 'language_selector.dart';
 import 'locale_provider.dart';
 import 'theme_mode_button.dart';
 import 'ticket_success_page.dart';
+import 'mowiz_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -655,6 +656,25 @@ class _HomePageState extends State<HomePage> {
                   TextButton(
                     onPressed: _refreshPage,
                     child: Text(AppLocalizations.of(context).t('cancel')),
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const MowizPage(),
+                        ),
+                      );
+                    },
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                      padding: const EdgeInsets.symmetric(vertical: 24),
+                      textStyle: const TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    child: const Text('MOWIZ'),
                   ),
                 ],
               ),

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'language_selector.dart';
+import 'theme_mode_button.dart';
+
+class MowizPage extends StatelessWidget {
+  const MowizPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Simulador MOWIZ'),
+        actions: const [
+          LanguageSelector(),
+          SizedBox(width: 8),
+          ThemeModeButton(),
+        ],
+      ),
+      body: const SizedBox.shrink(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add "MOWIZ" simulator page
- link to new page from HomePage with modern Material 3 button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f78b0e16c833291f0c734bea47f55