### PR TITLE
Add setup script for Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Error: Couldn't resolve the package 'cloud_functions_web'
 
 Ejecutar `flutter pub get` soluciona el problema.
 
+## Configuración rápida de Flutter
+
+Si el entorno no cuenta con Flutter instalado puedes usar el script
+`setup_flutter.sh` incluido en el repositorio:
+
+```bash
+source ./setup_flutter.sh
+```
+
+Este comando descarga el SDK de Flutter (3.19.2) y lo agrega al `PATH`
+de la sesión actual.
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.

--- a/setup_flutter.sh
+++ b/setup_flutter.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Simple helper to install Flutter SDK locally and add it to PATH
+# Usage: source ./setup_flutter.sh
+
+set -euo pipefail
+
+apt-get update
+apt-get install -y curl git unzip xz-utils
+
+FLUTTER_VERSION="3.19.2"
+ARCHIVE="flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+
+if [ ! -d flutter ]; then
+  curl -L -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/${ARCHIVE}"
+  tar -xJf "$ARCHIVE"
+  rm "$ARCHIVE"
+fi
+
+export PATH="$PWD/flutter/bin:$PATH"
+
+flutter --version
+


### PR DESCRIPTION
## Summary
- add a helper script `setup_flutter.sh` to install Flutter locally
- document the script in README

## Testing
- `source setup_flutter.sh` *(fails: Flutter requires a newer Dart SDK)*
- `flutter test` *(fails: Unable to 'pub upgrade' flutter tool)*


------
https://chatgpt.com/codex/tasks/task_e_687f941d69448332ac3b3927a0ac63cf