### PR TITLE
Fix onCancel call in TimeScreen

### DIFF
--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -227,7 +227,7 @@ class _TimeScreenState extends State<_TimeScreen> {
           builder: (_) => const TicketSuccessPage(ticketId: 'demo'),
         ),
       );
-      onCancel();
+      widget.onCancel();
     }
   }
 


### PR DESCRIPTION
## Summary
- fix invalid reference to onCancel in `TimeScreen`

## Testing
- `flutter test` *(fails: requires Dart SDK ^3.8.1 but flutter install has 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6880846305c08332aa2e59fcddb9f53f