### PR TITLE
Add MOWIZ actions pages

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -68,6 +68,9 @@ class AppLocalizations {
       'emergencyTitle': 'ADVERTENCIA',
       'autoCloseIn': 'Cierre automático en {seconds} s',
       'emergencyActiveLabel': 'Emergencia: {reason}',
+      'mowizTitle': 'Simulador MOWIZ',
+      'payTicket': 'Pagar ticket',
+      'cancelDenuncia': 'Anular denúncia',
     },
     'ca': {
       'welcome': 'Benvingut a Meypar Optima App',
@@ -122,6 +125,9 @@ class AppLocalizations {
       'emergencyTitle': 'Emergència',
       'autoCloseIn': 'Tancament automàtic en {seconds} s',
       'emergencyActiveLabel': 'Emergència: {reason}',
+      'mowizTitle': 'Simulador MOWIZ',
+      'payTicket': 'Pagar tiquet',
+      'cancelDenuncia': 'Anular denúncia',
     },
     'en': {
       'welcome': 'Welcome to Meypar Optima App',
@@ -176,6 +182,9 @@ class AppLocalizations {
       'emergencyTitle': 'Emergency',
       'autoCloseIn': 'Auto close in {seconds}s',
       'emergencyActiveLabel': 'Emergency: {reason}',
+      'mowizTitle': 'MOWIZ simulator',
+      'payTicket': 'Pay ticket',
+      'cancelDenuncia': 'Cancel denuncia',
     },
   };
 

--- a/lib/mowiz_cancel_page.dart
+++ b/lib/mowiz_cancel_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'l10n/app_localizations.dart';
+
+class MowizCancelPage extends StatelessWidget {
+  const MowizCancelPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context).t;
+    return Scaffold(
+      appBar: AppBar(title: Text(t('cancelDenuncia'))),
+      body: const SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -1,22 +1,69 @@
 import 'package:flutter/material.dart';
 import 'language_selector.dart';
 import 'theme_mode_button.dart';
+import 'l10n/app_localizations.dart';
+import 'mowiz_pay_page.dart';
+import 'mowiz_cancel_page.dart';
 
 class MowizPage extends StatelessWidget {
   const MowizPage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context).t;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Simulador MOWIZ'),
+        title: Text(t('mowizTitle')),
         actions: const [
           LanguageSelector(),
           SizedBox(width: 8),
           ThemeModeButton(),
         ],
       ),
-      body: const SizedBox.shrink(),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const MowizPayPage(),
+                  ),
+                );
+              },
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+                textStyle: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              child: Text(t('payTicket')),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const MowizCancelPage(),
+                  ),
+                );
+              },
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+                textStyle: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              child: Text(t('cancelDenuncia')),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'l10n/app_localizations.dart';
+
+class MowizPayPage extends StatelessWidget {
+  const MowizPayPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context).t;
+    return Scaffold(
+      appBar: AppBar(title: Text(t('payTicket'))),
+      body: const SizedBox.shrink(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new pages for MOWIZ simulator flow
- build translated UI with big buttons on MowizPage
- add translations for new strings in Spanish, Catalan and English

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880984cf940833290fd82ca017686ed