### PR TITLE
Add zone selection UI

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -71,6 +71,11 @@ class AppLocalizations {
       'mowizTitle': 'Simulador MOWIZ',
       'payTicket': 'Pagar ticket',
       'cancelDenuncia': 'Anular denúncia',
+      'selectZone': 'Selecciona zona',
+      'zoneBlue': 'Zona azul',
+      'zoneGreen': 'Zona verde',
+      'enterPlate': 'Inserte matrícula',
+      'confirm': 'Confirmar',
     },
     'ca': {
       'welcome': 'Benvingut a Meypar Optima App',
@@ -128,6 +133,11 @@ class AppLocalizations {
       'mowizTitle': 'Simulador MOWIZ',
       'payTicket': 'Pagar tiquet',
       'cancelDenuncia': 'Anular denúncia',
+      'selectZone': 'Selecciona zona',
+      'zoneBlue': 'Zona blava',
+      'zoneGreen': 'Zona verda',
+      'enterPlate': 'Introdueix matrícula',
+      'confirm': 'Confirmar',
     },
     'en': {
       'welcome': 'Welcome to Meypar Optima App',
@@ -185,6 +195,11 @@ class AppLocalizations {
       'mowizTitle': 'MOWIZ simulator',
       'payTicket': 'Pay ticket',
       'cancelDenuncia': 'Cancel denuncia',
+      'selectZone': 'Select zone',
+      'zoneBlue': 'Blue zone',
+      'zoneGreen': 'Green zone',
+      'enterPlate': 'Enter plate',
+      'confirm': 'Confirm',
     },
   };
 

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -1,15 +1,101 @@
 import 'package:flutter/material.dart';
 import 'l10n/app_localizations.dart';
 
-class MowizPayPage extends StatelessWidget {
+class MowizPayPage extends StatefulWidget {
   const MowizPayPage({super.key});
+
+  @override
+  State<MowizPayPage> createState() => _MowizPayPageState();
+}
+
+class _MowizPayPageState extends State<MowizPayPage> {
+  String? _selectedZone; // 'blue' or 'green'
+  final _plateCtrl = TextEditingController();
+
+  bool get _confirmEnabled =>
+      _selectedZone != null && _plateCtrl.text.trim().isNotEmpty;
+
+  @override
+  void dispose() {
+    _plateCtrl.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context).t;
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(title: Text(t('payTicket'))),
-      body: const SizedBox.shrink(),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              t('selectZone'),
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () => setState(() => _selectedZone = 'blue'),
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 24),
+                      backgroundColor: _selectedZone == 'blue'
+                          ? colorScheme.primary
+                          : colorScheme.secondary,
+                    ),
+                    child: Text(t('zoneBlue')),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () => setState(() => _selectedZone = 'green'),
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 24),
+                      backgroundColor: _selectedZone == 'green'
+                          ? colorScheme.primary
+                          : colorScheme.secondary,
+                    ),
+                    child: Text(t('zoneGreen')),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _plateCtrl,
+              enabled: _selectedZone != null,
+              decoration: InputDecoration(
+                labelText: t('plate'),
+                hintText: t('enterPlate'),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: _confirmEnabled ? () {} : null,
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+              ),
+              child: Text(t('confirm')),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+              ),
+              child: Text(t('cancel')),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- implement zone selection, plate input and confirm/cancel buttons on `MowizPayPage`
- localize new strings for Spanish, Catalan and English

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a5453d048332bd124e124aac112f