### PR TITLE
Fix mismatched Lottie.asset call

### DIFF
--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -128,8 +128,6 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
             Lottie.asset(
               'assets/success.json',
               package: 'kiosk_app',
-            Lottie.asset(
-              'assets/success.json',
               height: 150,
               repeat: false,
             ),


### PR DESCRIPTION
## Summary
- correct Lottie widget arguments in `MowizSuccessPage`

## Testing
- `npm test` *(fails: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e217d10c8332b0cba6167ce593e1