### PR TITLE
Fix animation asset path

### DIFF
--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -127,7 +127,6 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
             // Explicit package is needed so the asset is bundled correctly
             Lottie.asset(
               'assets/success.json',
-              package: 'kiosk_app',
               height: 150,
               repeat: false,
             ),


### PR DESCRIPTION
## Summary
- clean up Lottie asset call in `MowizSuccessPage`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e77539c4833290beb58f6633c63c