### PR TITLE
Unify MOWIZ pages with Material 3 theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'l10n/app_localizations.dart';
 import 'locale_provider.dart';
 import 'theme_provider.dart';
 import 'theme_mode_button.dart';
+import 'mowiz_theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -51,101 +52,9 @@ class MyApp extends StatelessWidget {
               GlobalWidgetsLocalizations.delegate,
               GlobalCupertinoLocalizations.delegate,
             ],
-            theme: ThemeData(
-              useMaterial3: true,
-              primaryColor: const Color(0xFFE62144),
-              scaffoldBackgroundColor: Colors.white,
-              colorScheme: ColorScheme.fromSeed(
-                seedColor: const Color(0xFFE62144),
-                secondary: const Color(0xFF7F7F7F),
-                background: Colors.white,
-              ),
-              appBarTheme: const AppBarTheme(
-                backgroundColor: Color(0xFFE62144),
-                foregroundColor: Colors.white,
-                elevation: 0,
-              ),
-              elevatedButtonTheme: ElevatedButtonThemeData(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(60),
-                  backgroundColor: const Color(0xFFE62144),
-                  foregroundColor: Colors.white,
-                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                  ),
-                ),
-              ),
-              textButtonTheme: TextButtonThemeData(
-                style: TextButton.styleFrom(
-                  minimumSize: const Size.fromHeight(60),
-                  backgroundColor: const Color(0xFF7F7F7F),
-                  foregroundColor: Colors.white,
-                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                  ),
-                ),
-              ),
-              inputDecorationTheme: InputDecorationTheme(
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-              ),
-            ),
-            darkTheme: ThemeData(
-              useMaterial3: true,
-              brightness: Brightness.dark,
-              scaffoldBackgroundColor: Colors.black,
-              colorScheme: ColorScheme.fromSeed(
-                seedColor: const Color(0xFFE62144),
-                brightness: Brightness.dark,
-                secondary: const Color(0xFF7F7F7F),
-              ),
-              appBarTheme: const AppBarTheme(
-                backgroundColor: Color(0xFFE62144),
-                foregroundColor: Colors.white,
-                elevation: 0,
-              ),
-              elevatedButtonTheme: ElevatedButtonThemeData(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(60),
-                  backgroundColor: const Color(0xFFE62144),
-                  foregroundColor: Colors.white,
-                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                  ),
-                ),
-              ),
-              textButtonTheme: TextButtonThemeData(
-                style: TextButton.styleFrom(
-                  minimumSize: const Size.fromHeight(60),
-                  backgroundColor: const Color(0xFF7F7F7F),
-                  foregroundColor: Colors.white,
-                  textStyle: const TextStyle(fontWeight: FontWeight.bold),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                  ),
-                ),
-              ),
-              inputDecorationTheme: InputDecorationTheme(
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-              ),
-              textTheme: const TextTheme(
-                bodyLarge: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                bodyMedium: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                titleLarge: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                titleMedium: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                titleSmall: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                labelLarge: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                labelMedium: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                labelSmall: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-              ),
-            ),
-            themeMode: themeProv.mode,
+            theme: mowizTheme(context),
+            darkTheme: mowizTheme(context),
+            themeMode: ThemeMode.system,
             home: const HomePage(),
           );
         },

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -20,49 +20,52 @@ class MowizPage extends StatelessWidget {
           ThemeModeButton(),
         ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => const MowizPayPage(),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final horizontal = constraints.maxWidth >= 600 ? 48.0 : 16.0;
+          return Padding(
+            padding: EdgeInsets.all(horizontal),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                FilledButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      PageRouteBuilder(
+                        transitionDuration: const Duration(milliseconds: 300),
+                        pageBuilder: (_, __, ___) => const MowizPayPage(),
+                        transitionsBuilder: (_, anim, __, child) =>
+                            FadeTransition(opacity: anim, child: child),
+                      ),
+                    );
+                  },
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
                   ),
-                );
-              },
-              style: FilledButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                textStyle: const TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
+                  child: Text(t('payTicket')),
                 ),
-              ),
-              child: Text(t('payTicket')),
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => const MowizCancelPage(),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      PageRouteBuilder(
+                        transitionDuration: const Duration(milliseconds: 300),
+                        pageBuilder: (_, __, ___) => const MowizCancelPage(),
+                        transitionsBuilder: (_, anim, __, child) =>
+                            FadeTransition(opacity: anim, child: child),
+                      ),
+                    );
+                  },
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
                   ),
-                );
-              },
-              style: FilledButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                textStyle: const TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
+                  child: Text(t('cancelDenuncia')),
                 ),
-              ),
-              child: Text(t('cancelDenuncia')),
+              ],
             ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -28,85 +28,96 @@ class _MowizPayPageState extends State<MowizPayPage> {
     final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(title: Text(t('payTicket'))),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              t('selectZone'),
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
-            ),
-            const SizedBox(height: 16),
-            Row(
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final horizontal = constraints.maxWidth >= 600 ? 48.0 : 16.0;
+          return Padding(
+            padding: EdgeInsets.all(horizontal),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => setState(() => _selectedZone = 'blue'),
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 24),
-                      backgroundColor: _selectedZone == 'blue'
-                          ? colorScheme.primary
-                          : colorScheme.secondary,
-                    ),
-                    child: Text(t('zoneBlue')),
-                  ),
+                Text(
+                  t('selectZone'),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      fontWeight: FontWeight.bold, fontSize: 20),
                 ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => setState(() => _selectedZone = 'green'),
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 24),
-                      backgroundColor: _selectedZone == 'green'
-                          ? colorScheme.primary
-                          : colorScheme.secondary,
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => setState(() => _selectedZone = 'blue'),
+                        style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 24),
+                          backgroundColor: _selectedZone == 'blue'
+                              ? colorScheme.primary
+                              : colorScheme.secondary,
+                        ),
+                        child: Text(t('zoneBlue')),
+                      ),
                     ),
-                    child: Text(t('zoneGreen')),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () =>
+                            setState(() => _selectedZone = 'green'),
+                        style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 24),
+                          backgroundColor: _selectedZone == 'green'
+                              ? colorScheme.primary
+                              : colorScheme.secondary,
+                        ),
+                        child: Text(t('zoneGreen')),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _plateCtrl,
+                  enabled: _selectedZone != null,
+                  decoration: InputDecoration(
+                    labelText: t('plate'),
+                    hintText: t('enterPlate'),
                   ),
+                  onChanged: (_) => setState(() {}),
+                ),
+                const SizedBox(height: 32),
+                ElevatedButton(
+                  onPressed: _confirmEnabled
+                      ? () {
+                          Navigator.of(context).push(
+                            PageRouteBuilder(
+                              transitionDuration:
+                                  const Duration(milliseconds: 300),
+                              pageBuilder: (_, __, ___) => MowizTimePage(
+                                zone: _selectedZone!,
+                                plate: _plateCtrl.text.trim(),
+                              ),
+                              transitionsBuilder: (_, anim, __, child) =>
+                                  FadeTransition(opacity: anim, child: child),
+                            ),
+                          );
+                        }
+                      : null,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
+                  ),
+                  child: Text(t('confirm')),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  style: TextButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
+                  ),
+                  child: Text(t('cancel')),
                 ),
               ],
             ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: _plateCtrl,
-              enabled: _selectedZone != null,
-              decoration: InputDecoration(
-                labelText: t('plate'),
-                hintText: t('enterPlate'),
-              ),
-              onChanged: (_) => setState(() {}),
-            ),
-            const SizedBox(height: 32),
-            ElevatedButton(
-              onPressed: _confirmEnabled
-                  ? () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (_) => MowizTimePage(
-                            zone: _selectedZone!,
-                            plate: _plateCtrl.text.trim(),
-                          ),
-                        ),
-                      );
-                    }
-                  : null,
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-              ),
-              child: Text(t('confirm')),
-            ),
-            const SizedBox(height: 16),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              style: TextButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-              ),
-              child: Text(t('cancel')),
-            ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lottie/lottie.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'package:confetti/confetti.dart';
 
 import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
@@ -33,6 +34,8 @@ class MowizSuccessPage extends StatefulWidget {
 class _MowizSuccessPageState extends State<MowizSuccessPage> {
   static const double _buttonHeight = 44;
   static const TextStyle _buttonTextStyle = TextStyle(fontSize: 16);
+  final _confetti = ConfettiController(duration: const Duration(seconds: 3));
+  bool _showTick = false;
   int _seconds = 30;
   Timer? _timer;
 
@@ -40,6 +43,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
   void initState() {
     super.initState();
     _startTimer();
+    _confetti.play();
+    Future.delayed(const Duration(milliseconds: 250), () {
+      if (mounted) setState(() => _showTick = true);
+    });
   }
 
   void _startTimer() {
@@ -106,6 +113,7 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
   @override
   void dispose() {
     _timer?.cancel();
+    _confetti.dispose();
     super.dispose();
   }
 
@@ -123,146 +131,174 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
 
     return Scaffold(
       appBar: AppBar(automaticallyImplyLeading: false),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Lottie.asset(
-              'assets/success.json',
-              height: 120,
-              repeat: false,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              t('paymentSuccess'),
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 8),
-            SizedBox(
-              height: 200,
-              child: Center(
-                child: QrImageView(
-                  data:
-                      'ticket|plate:${widget.plate}|zone:${widget.zone}|start:${widget.start.toIso8601String()}|end:${finish.toIso8601String()}|price:${widget.price}',
-                  version: QrVersions.auto,
-                  size: 180,
-                  foregroundColor: Theme.of(context).brightness == Brightness.dark
-                      ? Colors.white
-                      : Colors.black,
-                ),
-              ),
-            ),
-            const SizedBox(height: 8),
-            Expanded(
-              child: Card(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(24),
-                ),
-                elevation: 4,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Text(
-                        t('ticketSummary'),
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      Text(
-                        '${t('plate')}: ${widget.plate}',
-                        style: const TextStyle(fontSize: 16),
-                      ),
-                      Text(
-                        '${t('zone')}: ${widget.zone}',
-                        style: const TextStyle(fontSize: 16),
-                      ),
-                      Text(
-                        '${t('startTime')}: ${timeFormat.format(widget.start)}',
-                        style: const TextStyle(fontSize: 16),
-                      ),
-                      Text(
-                        '${t('endTime')}: ${timeFormat.format(finish)}',
-                        style: const TextStyle(fontSize: 16),
-                      ),
-                      Text(
-                        '${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €',
-                        style: const TextStyle(fontSize: 16),
-                      ),
-                      Text(
-                        '${t('paymentMethod')}: ${widget.method}',
-                        style: const TextStyle(fontSize: 16),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final horizontal = constraints.maxWidth >= 600 ? 48.0 : 16.0;
+          return Padding(
+            padding: EdgeInsets.all(horizontal),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Expanded(
-                  child: Column(
-                    children: [
-                      ElevatedButton(
-                        onPressed: () {},
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('printTicket')),
+                Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    ConfettiWidget(
+                      confettiController: _confetti,
+                      blastDirectionality: BlastDirectionality.explosive,
+                      shouldLoop: false,
+                    ),
+                    AnimatedScale(
+                      scale: _showTick ? 1 : 0,
+                      duration: const Duration(milliseconds: 250),
+                      child: Lottie.asset(
+                        'assets/success.json',
+                        height: 120,
+                        repeat: false,
                       ),
-                      const SizedBox(height: 8),
-                      ElevatedButton(
-                        onPressed: _showEmailDialog,
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('sendByEmail')),
-                      ),
-                    ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  t('paymentSuccess'),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  height: 200,
+                  child: Center(
+                    child: QrImageView(
+                      // TODO: replace static data with real ticket JSON from backend
+                      data:
+                          'ticket|plate:${widget.plate}|zone:${widget.zone}|start:${widget.start.toIso8601String()}|end:${finish.toIso8601String()}|price:${widget.price}',
+                      version: QrVersions.auto,
+                      size: 180,
+                      foregroundColor:
+                          Theme.of(context).brightness == Brightness.dark
+                              ? Colors.white
+                              : Colors.black,
+                    ),
                   ),
                 ),
-                const SizedBox(width: 8),
+                const SizedBox(height: 8),
                 Expanded(
-                  child: Column(
-                    children: [
-                      ElevatedButton(
-                        onPressed: _showSmsDialog,
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('sendBySms')),
+                  child: Card(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    elevation: 4,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          Text(
+                            t('ticketSummary'),
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          Text(
+                            '${t('plate')}: ${widget.plate}',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          Text(
+                            '${t('zone')}: ${widget.zone}',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          Text(
+                            '${t('startTime')}: ${timeFormat.format(widget.start)}',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          Text(
+                            '${t('endTime')}: ${timeFormat.format(finish)}',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          Text(
+                            '${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                          Text(
+                            '${t('paymentMethod')}: ${widget.method}',
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                        ],
                       ),
-                      const SizedBox(height: 8),
-                      ElevatedButton(
-                        onPressed: _goHome,
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('goHome')),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        children: [
+                          ElevatedButton(
+                            onPressed: () {},
+                            style: ElevatedButton.styleFrom(
+                              minimumSize: Size.fromHeight(_buttonHeight),
+                              textStyle: _buttonTextStyle,
+                            ),
+                            child: Text(t('printTicket')),
+                          ),
+                          const SizedBox(height: 8),
+                          ElevatedButton(
+                            onPressed: _showEmailDialog,
+                            style: ElevatedButton.styleFrom(
+                              minimumSize: Size.fromHeight(_buttonHeight),
+                              textStyle: _buttonTextStyle,
+                            ),
+                            child: Text(t('sendByEmail')),
+                          ),
+                        ],
                       ),
-                    ],
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Column(
+                        children: [
+                          ElevatedButton(
+                            onPressed: _showSmsDialog,
+                            style: ElevatedButton.styleFrom(
+                              minimumSize: Size.fromHeight(_buttonHeight),
+                              textStyle: _buttonTextStyle,
+                            ),
+                            child: Text(t('sendBySms')),
+                          ),
+                          const SizedBox(height: 8),
+                          ElevatedButton(
+                            onPressed: _goHome,
+                            style: ElevatedButton.styleFrom(
+                              minimumSize: Size.fromHeight(_buttonHeight),
+                              textStyle: _buttonTextStyle,
+                            ),
+                            child: Text(t('goHome')),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                TweenAnimationBuilder<double>(
+                  tween: Tween(
+                      begin: _seconds.toDouble() + 1, end: _seconds.toDouble()),
+                  duration: const Duration(milliseconds: 250),
+                  builder: (context, value, child) => Text(
+                    t('returningIn',
+                        params: {'seconds': value.toInt().toString()}),
+                    textAlign: TextAlign.center,
                   ),
                 ),
               ],
             ),
-            const SizedBox(height: 8),
-            Text(
-              t('returningIn', params: {'seconds': '$_seconds'}),
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
@@ -339,57 +375,33 @@ class _SmsDialogState extends State<_SmsDialog> {
 }
 
 // Email sent confirmation dialog
-class _EmailSentDialog extends StatefulWidget {
+class _EmailSentDialog extends StatelessWidget {
   final VoidCallback onClose;
   const _EmailSentDialog({required this.onClose});
-
-  @override
-  State<_EmailSentDialog> createState() => _EmailSentDialogState();
-}
-
-class _EmailSentDialogState extends State<_EmailSentDialog> {
-  int _seconds = 10;
-  Timer? _timer;
-
-  @override
-  void initState() {
-    super.initState();
-    _timer = Timer.periodic(const Duration(seconds: 1), (t) {
-      if (_seconds > 1) {
-        setState(() => _seconds--);
-      } else {
-        t.cancel();
-        if (mounted) {
-          Navigator.of(context).pop();
-          widget.onClose();
-        }
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return AlertDialog(
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(l.t('emailSent')),
-          const SizedBox(height: 8),
-          Text(l.t('returningIn', params: {'seconds': '$_seconds'})),
-        ],
+      content: TweenAnimationBuilder<double>(
+        tween: Tween(begin: 10, end: 0),
+        duration: const Duration(seconds: 10),
+        onEnd: onClose,
+        builder: (context, value, child) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(l.t('emailSent')),
+            const SizedBox(height: 8),
+            Text(l.t('returningIn',
+                params: {'seconds': value.toInt().toString()})),
+          ],
+        ),
       ),
       actions: [
         ElevatedButton(
           onPressed: () {
             Navigator.of(context).pop();
-            widget.onClose();
+            onClose();
           },
           child: Text(l.t('close')),
         ),
@@ -399,57 +411,33 @@ class _EmailSentDialogState extends State<_EmailSentDialog> {
 }
 
 // SMS sent confirmation dialog
-class _SmsSentDialog extends StatefulWidget {
+class _SmsSentDialog extends StatelessWidget {
   final VoidCallback onClose;
   const _SmsSentDialog({required this.onClose});
-
-  @override
-  State<_SmsSentDialog> createState() => _SmsSentDialogState();
-}
-
-class _SmsSentDialogState extends State<_SmsSentDialog> {
-  int _seconds = 10;
-  Timer? _timer;
-
-  @override
-  void initState() {
-    super.initState();
-    _timer = Timer.periodic(const Duration(seconds: 1), (t) {
-      if (_seconds > 1) {
-        setState(() => _seconds--);
-      } else {
-        t.cancel();
-        if (mounted) {
-          Navigator.of(context).pop();
-          widget.onClose();
-        }
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return AlertDialog(
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(l.t('smsSent')),
-          const SizedBox(height: 8),
-          Text(l.t('returningIn', params: {'seconds': '$_seconds'})),
-        ],
+      content: TweenAnimationBuilder<double>(
+        tween: Tween(begin: 10, end: 0),
+        duration: const Duration(seconds: 10),
+        onEnd: onClose,
+        builder: (context, value, child) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(l.t('smsSent')),
+            const SizedBox(height: 8),
+            Text(l.t('returningIn',
+                params: {'seconds': value.toInt().toString()})),
+          ],
+        ),
       ),
       actions: [
         ElevatedButton(
           onPressed: () {
             Navigator.of(context).pop();
-            widget.onClose();
+            onClose();
           },
           child: Text(l.t('close')),
         ),

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -56,11 +56,12 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
 
     Future<void> _pay() async {
       if (_method == null) return;
-      // TODO: integrate real payment logic and backend communication
+      // TODO: integrate real payment logic and call mock Express backend
       if (!mounted) return;
       await Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => MowizSuccessPage(
+        PageRouteBuilder(
+          transitionDuration: const Duration(milliseconds: 300),
+          pageBuilder: (_, __, ___) => MowizSuccessPage(
             plate: widget.plate,
             zone: widget.zone,
             start: widget.start,
@@ -68,90 +69,102 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
             price: widget.price,
             method: _method!,
           ),
+          transitionsBuilder: (_, anim, __, child) =>
+              FadeTransition(opacity: anim, child: child),
         ),
       );
     }
 
     return Scaffold(
       appBar: AppBar(title: Text(t('summaryPay'))),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(24),
-              ),
-              elevation: 4,
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Text(
-                      t('totalTime'),
-                      style: const TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final horizontal = constraints.maxWidth >= 600 ? 48.0 : 16.0;
+          return Padding(
+            padding: EdgeInsets.all(horizontal),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Card(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                  elevation: 4,
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          t('totalTime'),
+                          style: const TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          '${widget.minutes ~/ 60}h ${widget.minutes % 60}m',
+                          style: const TextStyle(fontSize: 36),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          "${t('startTime')}: ${timeFormat.format(widget.start)}",
+                          style: const TextStyle(fontSize: 20),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          "${t('endTime')}: ${timeFormat.format(finish)}",
+                          style: const TextStyle(fontSize: 20),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          "${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €",
+                          style: const TextStyle(
+                            fontSize: 24,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
                     ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '${widget.minutes ~/ 60}h ${widget.minutes % 60}m',
-                      style: const TextStyle(fontSize: 36),
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      "${t('startTime')}: ${timeFormat.format(widget.start)}",
-                      style: const TextStyle(fontSize: 20),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      "${t('endTime')}: ${timeFormat.format(finish)}",
-                      style: const TextStyle(fontSize: 20),
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      "${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €",
-                      style: const TextStyle(
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
+                const SizedBox(height: 24),
+                paymentButton('card', Icons.credit_card, t('card')),
+                const SizedBox(height: 16),
+                paymentButton('qr', Icons.qr_code_2, t('qrPay')),
+                const SizedBox(height: 16),
+                paymentButton('mobile', Icons.phone_iphone, t('mobilePay')),
+                const Spacer(),
+                ElevatedButton(
+                  onPressed: _method != null ? _pay : null,
+                  style: ElevatedButton.styleFrom(
+                    minimumSize: const Size.fromHeight(80),
+                  ),
+                  child: Text(t('pay')),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pushAndRemoveUntil(
+                      PageRouteBuilder(
+                        transitionDuration: const Duration(milliseconds: 300),
+                        pageBuilder: (_, __, ___) => const MowizPage(),
+                        transitionsBuilder: (_, anim, __, child) =>
+                            FadeTransition(opacity: anim, child: child),
+                      ),
+                      (route) => false,
+                    );
+                  },
+                  style: TextButton.styleFrom(
+                    minimumSize: const Size.fromHeight(80),
+                  ),
+                  child: Text(t('cancel')),
+                ),
+              ],
             ),
-            const SizedBox(height: 24),
-            paymentButton('card', Icons.credit_card, t('card')),
-            const SizedBox(height: 16),
-            paymentButton('qr', Icons.qr_code_2, t('qrPay')),
-            const SizedBox(height: 16),
-            paymentButton('mobile', Icons.phone_iphone, t('mobilePay')),
-            const Spacer(),
-            ElevatedButton(
-              onPressed: _method != null ? _pay : null,
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(80),
-              ),
-              child: Text(t('pay')),
-            ),
-            const SizedBox(height: 16),
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pushAndRemoveUntil(
-                  MaterialPageRoute(builder: (_) => const MowizPage()),
-                  (route) => false,
-                );
-              },
-              style: TextButton.styleFrom(
-                minimumSize: const Size.fromHeight(80),
-              ),
-              child: Text(t('cancel')),
-            ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/mowiz_theme.dart
+++ b/lib/mowiz_theme.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+/// Global MOWIZ theme using Material 3.
+/// On Android 12+ you can integrate [dynamic_color]
+/// to obtain a seed from the system palette.
+ThemeData mowizTheme(BuildContext context) {
+  const seed = Color(0xFF0066CC); // corporate color
+  final light =
+      ColorScheme.fromSeed(seedColor: seed, brightness: Brightness.light);
+  final dark =
+      ColorScheme.fromSeed(seedColor: seed, brightness: Brightness.dark);
+  return ThemeData(
+    useMaterial3: true,
+    colorScheme: MediaQuery.of(context).platformBrightness == Brightness.dark
+        ? dark
+        : light,
+    textTheme: Theme.of(context).textTheme.apply(fontSizeFactor: 1.2),
+    visualDensity: VisualDensity.standard,
+  );
+}

--- a/lib/mowiz_time_page.dart
+++ b/lib/mowiz_time_page.dart
@@ -59,113 +59,130 @@ class _MowizTimePageState extends State<MowizTimePage> {
 
     return Scaffold(
       appBar: AppBar(title: Text(t('selectDuration'))),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              DateFormat('EEE, d MMM yyyy - HH:mm', locale).format(_now),
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 32),
-            Row(
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final horizontal = constraints.maxWidth >= 600 ? 48.0 : 16.0;
+          return Padding(
+            padding: EdgeInsets.all(horizontal),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => _modifyMinutes(3),
-                    child: const Text('+3'),
-                  ),
+                Text(
+                  DateFormat('EEE, d MMM yyyy - HH:mm', locale).format(_now),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      fontSize: 32, fontWeight: FontWeight.bold),
                 ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => _modifyMinutes(5),
-                    child: const Text('+5'),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => _modifyMinutes(15),
-                    child: const Text('+15'),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => _modifyMinutes(-3),
-                    child: const Text('-3'),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => _modifyMinutes(-5),
-                    child: const Text('-5'),
-                  ),
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () => _modifyMinutes(-15),
-                    child: const Text('-15'),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 32),
-            Text(
-              durationStr,
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 40, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              '${t('price')}: ${price.toStringAsFixed(2)} €',
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              '${t('until')}: ${DateFormat('HH:mm', locale).format(finish)}',
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            const Spacer(),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => MowizSummaryPage(
-                      plate: widget.plate,
-                      zone: widget.zone,
-                      start: _now,
-                      minutes: _minutes,
-                      price: price,
+                const SizedBox(height: 32),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => _modifyMinutes(3),
+                        child: const Text('+3'),
+                      ),
                     ),
-                  ),
-                );
-              },
-              child: Text(t('continue')),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => _modifyMinutes(5),
+                        child: const Text('+5'),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => _modifyMinutes(15),
+                        child: const Text('+15'),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => _modifyMinutes(-3),
+                        child: const Text('-3'),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => _modifyMinutes(-5),
+                        child: const Text('-5'),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => _modifyMinutes(-15),
+                        child: const Text('-15'),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 32),
+                Text(
+                  durationStr,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      fontSize: 40, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  '${t('price')}: ${price.toStringAsFixed(2)} €',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  '${t('until')}: ${DateFormat('HH:mm', locale).format(finish)}',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+                const Spacer(),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      PageRouteBuilder(
+                        transitionDuration: const Duration(milliseconds: 300),
+                        pageBuilder: (_, __, ___) => MowizSummaryPage(
+                          plate: widget.plate,
+                          zone: widget.zone,
+                          start: _now,
+                          minutes: _minutes,
+                          price: price,
+                        ),
+                        transitionsBuilder: (_, anim, __, child) =>
+                            FadeTransition(opacity: anim, child: child),
+                      ),
+                    );
+                  },
+                  child: Text(t('continue')),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pushAndRemoveUntil(
+                      PageRouteBuilder(
+                        transitionDuration: const Duration(milliseconds: 300),
+                        pageBuilder: (_, __, ___) => const MowizPage(),
+                        transitionsBuilder: (_, anim, __, child) =>
+                            FadeTransition(opacity: anim, child: child),
+                      ),
+                      (route) => false,
+                    );
+                  },
+                  child: Text(t('cancel')),
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pushAndRemoveUntil(
-                  MaterialPageRoute(builder: (_) => const MowizPage()),
-                  (route) => false,
-                );
-              },
-              child: Text(t('cancel')),
-            ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   intl: ^0.20.2              # Formateo de fechas y monedas
   provider: ^6.1.2
   lottie: ^2.7.0             # Animaciones Lottie para la página de éxito
+  confetti: ^0.7.0          # Efecto confeti en la pantalla de éxito
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create shared Material 3 theme
- apply global theme in `main.dart`
- refactor MOWIZ pages to use responsive paddings and fade transitions
- add confetti and animated tick on payment success
- include `confetti` dependency

## Testing
- `dart format lib/mowiz_success_page.dart` *(passes)*
- `dart format lib/mowiz_theme.dart lib/main.dart lib/mowiz_page.dart lib/mowiz_pay_page.dart lib/mowiz_time_page.dart lib/mowiz_summary_page.dart lib/mowiz_success_page.dart` *(passes)*
- `flutter pub get` *(fails: Dart SDK version 3.3.4 < 3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_6882447c9e008332864f14ffc2edaad1