### PR TITLE
Add language actions on MowizPage and enlarge pay page UI

### DIFF
--- a/lib/mowiz/mowiz_scaffold.dart
+++ b/lib/mowiz/mowiz_scaffold.dart
@@ -3,7 +3,13 @@ import 'package:flutter/material.dart';
 class MowizScaffold extends StatelessWidget {
   final Widget body;
   final String? title;
-  const MowizScaffold({required this.body, this.title, super.key});
+  final List<Widget>? actions;
+  const MowizScaffold({
+    required this.body,
+    this.title,
+    this.actions,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +27,12 @@ class MowizScaffold extends StatelessWidget {
     return Theme(
       data: mowizTheme,
       child: Scaffold(
-        appBar: title == null ? null : AppBar(title: Text(title!)),
+        appBar: title == null
+            ? null
+            : AppBar(
+                title: Text(title!),
+                actions: actions,
+              ),
         body: body,
       ),
     );

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -14,6 +14,11 @@ class MowizPage extends StatelessWidget {
     final t = AppLocalizations.of(context).t;
     return MowizScaffold(
       title: t('mowizTitle'),
+      actions: const [
+        LanguageSelector(),
+        SizedBox(width: 8),
+        ThemeModeButton(),
+      ],
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -37,7 +37,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
             Text(
               t('selectZone'),
               textAlign: TextAlign.center,
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
             ),
             const SizedBox(height: 16),
             Row(
@@ -51,7 +51,10 @@ class _MowizPayPageState extends State<MowizPayPage> {
                           ? colorScheme.primary
                           : colorScheme.secondary,
                     ),
-                    child: Text(t('zoneBlue')),
+                    child: Text(
+                      t('zoneBlue'),
+                      style: const TextStyle(fontSize: 24),
+                    ),
                   ),
                 ),
                 const SizedBox(width: 16),
@@ -64,7 +67,10 @@ class _MowizPayPageState extends State<MowizPayPage> {
                           ? colorScheme.primary
                           : colorScheme.secondary,
                     ),
-                    child: Text(t('zoneGreen')),
+                    child: Text(
+                      t('zoneGreen'),
+                      style: const TextStyle(fontSize: 24),
+                    ),
                   ),
                 ),
               ],
@@ -77,6 +83,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                 labelText: t('plate'),
                 hintText: t('enterPlate'),
               ),
+              style: const TextStyle(fontSize: 24),
               onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 32),
@@ -95,6 +102,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                   : null,
               style: ElevatedButton.styleFrom(
                 padding: const EdgeInsets.symmetric(vertical: 24),
+                textStyle: const TextStyle(fontSize: 24),
               ),
               child: Text(t('confirm')),
             ),
@@ -103,6 +111,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
               onPressed: () => Navigator.of(context).pop(),
               style: TextButton.styleFrom(
                 padding: const EdgeInsets.symmetric(vertical: 24),
+                textStyle: const TextStyle(fontSize: 24),
               ),
               child: Text(t('cancel')),
             ),


### PR DESCRIPTION
## Summary
- allow MowizScaffold to receive AppBar actions
- keep language selector and dark mode button when opening MowizPage
- enlarge fonts in MowizPayPage for better tablet readability

## Testing
- `npm test` *(fails: no test specified)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883311b8cec83329e6e6b6ba771d574