### PR TITLE
Improve MOWIZ button layouts

### DIFF
--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -5,6 +5,8 @@ import 'l10n/app_localizations.dart';
 import 'mowiz_pay_page.dart';
 import 'mowiz_cancel_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
+// Estilo de botones grandes reutilizable
+import 'styles/mowiz_buttons.dart';
 
 class MowizPage extends StatelessWidget {
   const MowizPage({super.key});
@@ -33,13 +35,8 @@ class MowizPage extends StatelessWidget {
                   ),
                 );
               },
-              style: FilledButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                textStyle: const TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              // Uso de estilo común para botones grandes
+              style: kMowizFilledButtonStyle,
               child: Text(t('payTicket')),
             ),
             const SizedBox(height: 16),
@@ -51,13 +48,8 @@ class MowizPage extends StatelessWidget {
                   ),
                 );
               },
-              style: FilledButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                textStyle: const TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              // Uso de estilo común para botones grandes
+              style: kMowizFilledButtonStyle,
               child: Text(t('cancelDenuncia')),
             ),
           ],

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz_time_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
+// Estilo común para botones grandes
+import 'styles/mowiz_buttons.dart';
 
 class MowizPayPage extends StatefulWidget {
   const MowizPayPage({super.key});
@@ -87,7 +89,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
               onChanged: (_) => setState(() {}),
             ),
             const SizedBox(height: 32),
-            ElevatedButton(
+            FilledButton(
               onPressed: _confirmEnabled
                   ? () {
                       Navigator.of(context).push(
@@ -100,19 +102,15 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       );
                     }
                   : null,
-              style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                textStyle: const TextStyle(fontSize: 24),
-              ),
+              // Estilo grande reutilizado
+              style: kMowizFilledButtonStyle,
               child: Text(t('confirm')),
             ),
             const SizedBox(height: 16),
-            TextButton(
+            FilledButton(
               onPressed: () => Navigator.of(context).pop(),
-              style: TextButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                textStyle: const TextStyle(fontSize: 24),
-              ),
+              // Estilo grande reutilizado
+              style: kMowizFilledButtonStyle,
               child: Text(t('cancel')),
             ),
           ],

--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -9,6 +9,8 @@ import 'package:confetti/confetti.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
+// Estilo de botones grandes reutilizable para toda la app
+import 'styles/mowiz_buttons.dart';
 
 class MowizSuccessPage extends StatefulWidget {
   final String plate;
@@ -33,8 +35,6 @@ class MowizSuccessPage extends StatefulWidget {
 }
 
 class _MowizSuccessPageState extends State<MowizSuccessPage> {
-  static const double _buttonHeight = 44;
-  static const TextStyle _buttonTextStyle = TextStyle(fontSize: 16);
   int _seconds = 30;
   Timer? _timer;
   late final ConfettiController _confettiController;
@@ -171,7 +171,9 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
               ),
             ),
             const SizedBox(height: 8),
-            Expanded(
+            // Altura reducida para dejar espacio a los botones inferiores
+            SizedBox(
+              height: 170,
               child: Card(
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(24),
@@ -220,55 +222,32 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
               ),
             ),
             const SizedBox(height: 16),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
+            // Botones grandes apilados verticalmente
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Expanded(
-                  child: Column(
-                    children: [
-                      ElevatedButton(
-                        onPressed: () {},
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('printTicket')),
-                      ),
-                      const SizedBox(height: 8),
-                      ElevatedButton(
-                        onPressed: _showEmailDialog,
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('sendByEmail')),
-                      ),
-                    ],
-                  ),
+                FilledButton(
+                  onPressed: () {},
+                  style: kMowizFilledButtonStyle,
+                  child: Text(t('printTicket')),
                 ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Column(
-                    children: [
-                      ElevatedButton(
-                        onPressed: _showSmsDialog,
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('sendBySms')),
-                      ),
-                      const SizedBox(height: 8),
-                      ElevatedButton(
-                        onPressed: _goHome,
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.fromHeight(_buttonHeight),
-                          textStyle: _buttonTextStyle,
-                        ),
-                        child: Text(t('goHome')),
-                      ),
-                    ],
-                  ),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: _showSmsDialog,
+                  style: kMowizFilledButtonStyle,
+                  child: Text(t('sendBySms')),
+                ),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: _showEmailDialog,
+                  style: kMowizFilledButtonStyle,
+                  child: Text(t('sendByEmail')),
+                ),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: _goHome,
+                  style: kMowizFilledButtonStyle,
+                  child: Text(t('goHome')),
                 ),
               ],
             ),

--- a/lib/styles/mowiz_buttons.dart
+++ b/lib/styles/mowiz_buttons.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+/// Common big button style used across MOWIZ screens.
+final ButtonStyle kMowizFilledButtonStyle = FilledButton.styleFrom(
+  padding: const EdgeInsets.symmetric(vertical: 24),
+  textStyle: const TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.bold,
+  ),
+);


### PR DESCRIPTION
## Summary
- add `kMowizFilledButtonStyle` reusable style
- refactor MOWIZ pages to use the new big button style
- enlarge success page buttons and shrink ticket card

## Testing
- `apt-get update` *(fails: dart/flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68833fb96d848332bc41b995f9835ef4