### PR TITLE
Improve MOWIZ layout for tablets

### DIFF
--- a/lib/mowiz_cancel_page.dart
+++ b/lib/mowiz_cancel_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz/mowiz_scaffold.dart';
+import 'styles/mowiz_buttons.dart';
 
 class MowizCancelPage extends StatefulWidget {
   const MowizCancelPage({super.key});
@@ -33,12 +34,20 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
       builder: (ctx) => AlertDialog(
         content: Text(t('confirmCancellation')),
         actions: [
-          TextButton(
+          // Botón "No" del diálogo de confirmación
+          FilledButton(
             onPressed: () => Navigator.pop(ctx, false),
+            style: kMowizFilledButtonStyle.copyWith(
+              backgroundColor: MaterialStatePropertyAll(
+                Theme.of(ctx).colorScheme.secondary,
+              ),
+            ),
             child: Text(t('no')),
           ),
-          ElevatedButton(
+          // Botón "Sí" del diálogo de confirmación
+          FilledButton(
             onPressed: () => Navigator.pop(ctx, true),
+            style: kMowizFilledButtonStyle,
             child: Text(t('yes')),
           ),
         ],
@@ -70,17 +79,21 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
                 decoration: InputDecoration(hintText: t('enterPlate')),
               ),
               const SizedBox(height: 24),
-              ElevatedButton(
+              // Botón principal para validar la matrícula
+              FilledButton(
                 onPressed: _validate,
-                style:
-                    ElevatedButton.styleFrom(padding: const EdgeInsets.all(24)),
+                style: kMowizFilledButtonStyle,
                 child: Text(t('validate')),
               ),
               const SizedBox(height: 16),
-              TextButton(
+              // Botón de cancelación
+              FilledButton(
                 onPressed: () => Navigator.of(context).pop(),
-                style:
-                    TextButton.styleFrom(padding: const EdgeInsets.all(24)),
+                style: kMowizFilledButtonStyle.copyWith(
+                  backgroundColor: const MaterialStatePropertyAll(
+                    Color(0xFFA7A7A7),
+                  ),
+                ),
                 child: Text(t('cancel')),
               ),
             ],
@@ -137,9 +150,11 @@ class _SuccessDialogState extends State<_SuccessDialog> {
           Text(t('autoCloseIn', params: {'seconds': '$_seconds'})),
         ],
       ),
+      // Diálogo de éxito tras la anulación
       actions: [
-        ElevatedButton(
+        FilledButton(
           onPressed: () => Navigator.of(context).pop(),
+          style: kMowizFilledButtonStyle,
           child: Text(t('close')),
         ),
       ],

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -49,7 +49,9 @@ class MowizPage extends StatelessWidget {
                 );
               },
               // Uso de estilo común para botones grandes
-              style: kMowizFilledButtonStyle,
+              style: kMowizFilledButtonStyle.copyWith(
+                backgroundColor: const MaterialStatePropertyAll(Color(0xFFA7A7A7)),
+              ),
               child: Text(t('cancelDenuncia')),
             ),
           ],

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -45,34 +45,32 @@ class _MowizPayPageState extends State<MowizPayPage> {
             Row(
               children: [
                 Expanded(
-                  child: ElevatedButton(
+                  child: FilledButton(
                     onPressed: () => setState(() => _selectedZone = 'blue'),
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 24),
-                      backgroundColor: _selectedZone == 'blue'
-                          ? colorScheme.primary
-                          : colorScheme.secondary,
+                    style: kMowizFilledButtonStyle.copyWith(
+                      backgroundColor: MaterialStatePropertyAll(
+                        // Color corporativo para la zona azul
+                        _selectedZone == 'blue'
+                            ? const Color(0xFF007CF7)
+                            : colorScheme.secondary,
+                      ),
                     ),
-                    child: Text(
-                      t('zoneBlue'),
-                      style: const TextStyle(fontSize: 24),
-                    ),
+                    child: Text(t('zoneBlue')),
                   ),
                 ),
                 const SizedBox(width: 16),
                 Expanded(
-                  child: ElevatedButton(
+                  child: FilledButton(
                     onPressed: () => setState(() => _selectedZone = 'green'),
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 24),
-                      backgroundColor: _selectedZone == 'green'
-                          ? colorScheme.primary
-                          : colorScheme.secondary,
+                    style: kMowizFilledButtonStyle.copyWith(
+                      backgroundColor: MaterialStatePropertyAll(
+                        // Color corporativo para la zona verde
+                        _selectedZone == 'green'
+                            ? const Color(0xFF01AE00)
+                            : colorScheme.secondary,
+                      ),
                     ),
-                    child: Text(
-                      t('zoneGreen'),
-                      style: const TextStyle(fontSize: 24),
-                    ),
+                    child: Text(t('zoneGreen')),
                   ),
                 ),
               ],

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -5,6 +5,7 @@ import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
 import 'mowiz_success_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
+import 'styles/mowiz_buttons.dart';
 
 class MowizSummaryPage extends StatefulWidget {
   final String plate;
@@ -43,14 +44,14 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
     Widget paymentButton(String value, IconData icon, String text) {
       final selected = _method == value;
       final scheme = Theme.of(context).colorScheme;
-      return ElevatedButton.icon(
+      return FilledButton.icon(
         onPressed: () => setState(() => _method = value),
         icon: Icon(icon, size: 40),
         label: Text(text),
-        style: ElevatedButton.styleFrom(
-          minimumSize: const Size.fromHeight(80),
-          backgroundColor: selected ? scheme.primary : scheme.secondary,
-          foregroundColor: Colors.white,
+        style: kMowizFilledButtonStyle.copyWith(
+          backgroundColor: MaterialStatePropertyAll(
+            selected ? scheme.primary : scheme.secondary,
+          ),
         ),
       );
     }
@@ -77,19 +78,25 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
       title: t('summaryPay'),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Column(
+        // ScrollView para evitar overflow en pantallas pequeñas
+        child: SingleChildScrollView(
+          child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            // Cuadro con la información resumida del ticket.
+            // Ajusta `height` o `padding` si necesitas más espacio en el futuro.
             Card(
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(24),
               ),
               elevation: 4,
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
+              child: SizedBox(
+                height: 180,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
                     Text(
                       t('totalTime'),
                       style: const TextStyle(
@@ -124,30 +131,39 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                 ),
               ),
             ),
-            const SizedBox(height: 24),
-            paymentButton('card', Icons.credit_card, t('card')),
+            const SizedBox(height: 32),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: paymentButton('card', Icons.credit_card, t('card')),
+            ),
             const SizedBox(height: 16),
-            paymentButton('qr', Icons.qr_code_2, t('qrPay')),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: paymentButton('qr', Icons.qr_code_2, t('qrPay')),
+            ),
             const SizedBox(height: 16),
-            paymentButton('mobile', Icons.phone_iphone, t('mobilePay')),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: paymentButton('mobile', Icons.phone_iphone, t('mobilePay')),
+            ),
             const Spacer(),
-            ElevatedButton(
+            FilledButton(
               onPressed: _method != null ? _pay : null,
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(80),
-              ),
+              style: kMowizFilledButtonStyle,
               child: Text(t('pay')),
             ),
             const SizedBox(height: 16),
-            TextButton(
+            FilledButton(
               onPressed: () {
                 Navigator.of(context).pushAndRemoveUntil(
                   MaterialPageRoute(builder: (_) => const MowizPage()),
                   (route) => false,
                 );
               },
-              style: TextButton.styleFrom(
-                minimumSize: const Size.fromHeight(80),
+              style: kMowizFilledButtonStyle.copyWith(
+                backgroundColor: MaterialStatePropertyAll(
+                  Theme.of(context).colorScheme.secondary,
+                ),
               ),
               child: Text(t('cancel')),
             ),

--- a/lib/mowiz_time_page.dart
+++ b/lib/mowiz_time_page.dart
@@ -5,6 +5,7 @@ import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
 import 'mowiz_summary_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
+import 'styles/mowiz_buttons.dart';
 
 class MowizTimePage extends StatefulWidget {
   final String zone;
@@ -155,7 +156,8 @@ class _MowizTimePageState extends State<MowizTimePage> {
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
             const Spacer(),
-            ElevatedButton(
+            // Botón grande para continuar con el pago
+            FilledButton(
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
@@ -169,16 +171,23 @@ class _MowizTimePageState extends State<MowizTimePage> {
                   ),
                 );
               },
+              style: kMowizFilledButtonStyle,
               child: Text(t('continue')),
             ),
             const SizedBox(height: 16),
-            TextButton(
+            // Botón grande de cancelación
+            FilledButton(
               onPressed: () {
                 Navigator.of(context).pushAndRemoveUntil(
                   MaterialPageRoute(builder: (_) => const MowizPage()),
                   (route) => false,
                 );
               },
+              style: kMowizFilledButtonStyle.copyWith(
+                backgroundColor: MaterialStatePropertyAll(
+                  Theme.of(context).colorScheme.secondary,
+                ),
+              ),
               child: Text(t('cancel')),
             ),
           ],

--- a/lib/styles/mowiz_buttons.dart
+++ b/lib/styles/mowiz_buttons.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 
 /// Common big button style used across MOWIZ screens.
+/// Estilo reutilizable para los botones grandes de las pantallas MOWIZ.
+/// Se ha definido aquí para mantener consistencia en alturas y tipografías.
+/// Modifica `padding`, `minimumSize` o `textStyle` si necesitas
+/// personalizar la apariencia global de los botones.
 final ButtonStyle kMowizFilledButtonStyle = FilledButton.styleFrom(
-  padding: const EdgeInsets.symmetric(vertical: 24),
+  padding: const EdgeInsets.symmetric(vertical: 20),
+  minimumSize: const Size.fromHeight(60),
   textStyle: const TextStyle(
     fontSize: 24,
     fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- tweak global button style for large MOWIZ buttons
- update main MOWIZ menu colors
- adjust zone selection colors and buttons
- enlarge Continue/Cancel buttons
- fix overflow on summary page with scroll view and spacing
- refresh cancel page buttons and dialogs

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688344eb27bc8332a6514c98ab0b958d