### PR TITLE
Fix closing parentheses in Mowiz summary page

### DIFF
--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -131,6 +131,7 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                 ),
               ),
             ),
+            ),
             const SizedBox(height: 32),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 32),


### PR DESCRIPTION
## Summary
- fix unmatched parenthesis so Card widget compiles

## Testing
- `dart` or `flutter` were not available, so no tests were run


------
https://chatgpt.com/codex/tasks/task_e_6883482ae860833299694f8c06214eda