### PR TITLE
Fix Mowiz summary scaffold closure

### DIFF
--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -131,6 +131,7 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                 ),
               ),
             ),
+            ),
             const SizedBox(height: 32),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 32),
@@ -168,6 +169,7 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
               child: Text(t('cancel')),
             ),
           ],
+        ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- close final widget in summary page so scaffold compiles

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883482ae860833299694f8c06214eda