### PR TITLE
Fix crash in summary page

### DIFF
--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -147,7 +147,9 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
               padding: const EdgeInsets.symmetric(horizontal: 32),
               child: paymentButton('mobile', Icons.phone_iphone, t('mobilePay')),
             ),
-            const Spacer(),
+            // Spacer is not allowed inside SingleChildScrollView; use fixed
+            // spacing instead to avoid layout errors on this page.
+            const SizedBox(height: 32),
             FilledButton(
               onPressed: _method != null ? _pay : null,
               style: kMowizFilledButtonStyle,


### PR DESCRIPTION
## Summary
- fix unbounded layout crash by replacing `Spacer` with `SizedBox` in `MowizSummaryPage`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834e5ecb54833281c926ad81b4ad7e