### PR TITLE
Fix summary card layout

### DIFF
--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -84,17 +84,18 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             // Cuadro con la información resumida del ticket.
-            // Ajusta `height` o `padding` si necesitas más espacio en el futuro.
+            // Se deja crecer de forma dinámica y con scroll interno
+            // para evitar cualquier overflow si hay mucho texto.
             Card(
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(24),
               ),
               elevation: 4,
-              child: SizedBox(
-                height: 180,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: SingleChildScrollView(
                   child: Column(
+                    mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                     Text(


### PR DESCRIPTION
## Summary
- allow summary card to grow dynamically and scroll
- improve spacing before action buttons

## Testing
- `npm test` *(fails: "Error: no test specified")*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688351d34ff08332b1b6ba22741d7dae