### PR TITLE
Fix missing bracket in success page

### DIFF
--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -325,9 +325,9 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
             ),
           ],
         ),
-      ),
-        ],
-      ),
+      );
+    },
+  ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- fix closing bracket/parenthesis mismatch in `MowizSuccessPage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883612920d08332938f81595438c1b8