### PR TITLE
Fix closing of SuccessPage layout

### DIFF
--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -211,32 +211,32 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                         ),
                       ),
                       AutoSizeText(
-                        '${t('plate')}: ${widget.plate}',
+                        "${t('plate')}: ${widget.plate}",
                         maxLines: 1,
                         style: TextStyle(fontSize: titleFont - 8),
                       ),
                       AutoSizeText(
-                        '${t('zone')}: ${widget.zone}',
+                        "${t('zone')}: ${widget.zone}",
                         maxLines: 1,
                         style: TextStyle(fontSize: titleFont - 8),
                       ),
                       AutoSizeText(
-                        '${t('startTime')}: ${timeFormat.format(widget.start)}',
+                        "${t('startTime')}: ${timeFormat.format(widget.start)}",
                         maxLines: 1,
                         style: TextStyle(fontSize: titleFont - 8),
                       ),
                       AutoSizeText(
-                        '${t('endTime')}: ${timeFormat.format(finish)}',
+                        "${t('endTime')}: ${timeFormat.format(finish)}",
                         maxLines: 1,
                         style: TextStyle(fontSize: titleFont - 8),
                       ),
                       AutoSizeText(
-                        '${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €',
+                        "${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €",
                         maxLines: 1,
                         style: TextStyle(fontSize: titleFont - 8),
                       ),
                       AutoSizeText(
-                        '${t('paymentMethod')}: ${widget.method}',
+                        "${t('paymentMethod')}: ${widget.method}",
                         maxLines: 1,
                         style: TextStyle(fontSize: titleFont - 8),
                       ),
@@ -323,11 +323,13 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
               textAlign: TextAlign.center,
               style: TextStyle(fontSize: titleFont - 6),
             ),
-          ],
+            ],
+          ),
         ),
+        ],
       );
-    },
-  ),
+  },
+),
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure `SingleChildScrollView` is properly closed in `mowiz_success_page.dart`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688363fc5a3c8332be92743bcbd37283