### PR TITLE
Add tap sound across MOWIZ pages

### DIFF
--- a/lib/mowiz_cancel_page.dart
+++ b/lib/mowiz_cancel_page.dart
@@ -4,6 +4,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz/mowiz_scaffold.dart';
 import 'styles/mowiz_buttons.dart';
+import 'sound_helper.dart';
 
 class MowizCancelPage extends StatefulWidget {
   const MowizCancelPage({super.key});
@@ -37,7 +38,10 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
         actions: [
           // Botón "No" del diálogo de confirmación
           FilledButton(
-            onPressed: () => Navigator.pop(ctx, false),
+            onPressed: () {
+              SoundHelper.playTap();
+              Navigator.pop(ctx, false);
+            },
             style: kMowizFilledButtonStyle.copyWith(
               backgroundColor: MaterialStatePropertyAll(
                 Theme.of(ctx).colorScheme.secondary,
@@ -47,7 +51,10 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
           ),
           // Botón "Sí" del diálogo de confirmación
           FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
+            onPressed: () {
+              SoundHelper.playTap();
+              Navigator.pop(ctx, true);
+            },
             style: kMowizFilledButtonStyle,
             child: Text(t('yes')),
           ),
@@ -95,7 +102,10 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
                   ),
                   SizedBox(height: gap * 1.2),
                   FilledButton(
-                    onPressed: _validate,
+                    onPressed: () {
+                      SoundHelper.playTap();
+                      _validate();
+                    },
                     style: kMowizFilledButtonStyle.copyWith(
                       textStyle: MaterialStatePropertyAll(
                         TextStyle(fontSize: fontSize),
@@ -105,7 +115,10 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
                   ),
                   SizedBox(height: gap),
                   FilledButton(
-                    onPressed: () => Navigator.of(context).pop(),
+                    onPressed: () {
+                      SoundHelper.playTap();
+                      Navigator.of(context).pop();
+                    },
                     style: kMowizFilledButtonStyle.copyWith(
                       backgroundColor: const MaterialStatePropertyAll(
                         Color(0xFFA7A7A7),
@@ -183,7 +196,10 @@ class _SuccessDialogState extends State<_SuccessDialog> {
           ),
           actions: [
             FilledButton(
-              onPressed: () => Navigator.of(context).pop(),
+              onPressed: () {
+                SoundHelper.playTap();
+                Navigator.of(context).pop();
+              },
               style: kMowizFilledButtonStyle.copyWith(
                 textStyle: MaterialStatePropertyAll(TextStyle(fontSize: fontSize)),
               ),

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -8,6 +8,7 @@ import 'mowiz/mowiz_scaffold.dart';
 // Estilo de botones grandes reutilizable
 import 'styles/mowiz_buttons.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'sound_helper.dart';
 
 class MowizPage extends StatelessWidget {
   const MowizPage({super.key});
@@ -43,6 +44,7 @@ class MowizPage extends StatelessWidget {
           final payBtn = Expanded(
             child: FilledButton(
               onPressed: () {
+                SoundHelper.playTap();
                 Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (_) => const MowizPayPage(),
@@ -64,6 +66,7 @@ class MowizPage extends StatelessWidget {
           final cancelBtn = Expanded(
             child: FilledButton(
               onPressed: () {
+                SoundHelper.playTap();
                 Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (_) => const MowizCancelPage(),

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -5,6 +5,7 @@ import 'mowiz_time_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 // Estilo común para botones grandes
 import 'styles/mowiz_buttons.dart';
+import 'sound_helper.dart';
 
 class MowizPayPage extends StatefulWidget {
   const MowizPayPage({super.key});
@@ -53,7 +54,10 @@ class _MowizPayPageState extends State<MowizPayPage> {
           final zoneButton = (String value, String text, Color color) =>
               Expanded(
                 child: FilledButton(
-                  onPressed: () => setState(() => _selectedZone = value),
+                  onPressed: () {
+                    SoundHelper.playTap();
+                    setState(() => _selectedZone = value);
+                  },
                   style: kMowizFilledButtonStyle.copyWith(
                     backgroundColor: MaterialStatePropertyAll(
                       _selectedZone == value ? color : colorScheme.secondary,
@@ -115,6 +119,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                   FilledButton(
                     onPressed: _confirmEnabled
                         ? () {
+                            SoundHelper.playTap();
                             Navigator.of(context).push(
                               MaterialPageRoute(
                                 builder: (_) => MowizTimePage(
@@ -136,7 +141,10 @@ class _MowizPayPageState extends State<MowizPayPage> {
                   ),
                   SizedBox(height: gap),
                   FilledButton(
-                    onPressed: () => Navigator.of(context).pop(),
+                    onPressed: () {
+                      SoundHelper.playTap();
+                      Navigator.of(context).pop();
+                    },
                     style: kMowizFilledButtonStyle.copyWith(
                       textStyle:
                           MaterialStatePropertyAll(TextStyle(fontSize: titleFont)),

--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -12,6 +12,7 @@ import 'mowiz_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 // Estilo de botones grandes reutilizable para toda la app
 import 'styles/mowiz_buttons.dart';
+import 'sound_helper.dart';
 
 class MowizSuccessPage extends StatefulWidget {
   final String plate;
@@ -255,7 +256,9 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                         child: Padding(
                           padding: const EdgeInsets.only(right: 8),
                           child: FilledButton(
-                            onPressed: () {},
+                            onPressed: () {
+                              SoundHelper.playTap();
+                            },
                             style: kMowizFilledButtonStyle.copyWith(
                               textStyle: MaterialStatePropertyAll(
                                 TextStyle(fontSize: titleFont - 6),
@@ -269,7 +272,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                         child: Padding(
                           padding: const EdgeInsets.only(left: 8),
                           child: FilledButton(
-                            onPressed: _showSmsDialog,
+                            onPressed: () {
+                              SoundHelper.playTap();
+                              _showSmsDialog();
+                            },
                             style: kMowizFilledButtonStyle.copyWith(
                               textStyle: MaterialStatePropertyAll(
                                 TextStyle(fontSize: titleFont - 6),
@@ -288,7 +294,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                         child: Padding(
                           padding: const EdgeInsets.only(right: 8),
                           child: FilledButton(
-                            onPressed: _showEmailDialog,
+                            onPressed: () {
+                              SoundHelper.playTap();
+                              _showEmailDialog();
+                            },
                             style: kMowizFilledButtonStyle.copyWith(
                               textStyle: MaterialStatePropertyAll(
                                 TextStyle(fontSize: titleFont - 6),
@@ -302,7 +311,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                         child: Padding(
                           padding: const EdgeInsets.only(left: 8),
                           child: FilledButton(
-                            onPressed: _goHome,
+                            onPressed: () {
+                              SoundHelper.playTap();
+                              _goHome();
+                            },
                             style: kMowizFilledButtonStyle.copyWith(
                               textStyle: MaterialStatePropertyAll(
                                 TextStyle(fontSize: titleFont - 6),
@@ -357,11 +369,17 @@ class _EmailDialogState extends State<_EmailDialog> {
       ),
       actions: [
         TextButton(
-          onPressed: () => Navigator.pop(context),
+          onPressed: () {
+            SoundHelper.playTap();
+            Navigator.pop(context);
+          },
           child: Text(l.t('close')),
         ),
         ElevatedButton(
-          onPressed: () => Navigator.pop(context, _email.trim()),
+          onPressed: () {
+            SoundHelper.playTap();
+            Navigator.pop(context, _email.trim());
+          },
           child: Text(l.t('send')),
         ),
       ],
@@ -392,11 +410,17 @@ class _SmsDialogState extends State<_SmsDialog> {
       ),
       actions: [
         TextButton(
-          onPressed: () => Navigator.pop(context),
+          onPressed: () {
+            SoundHelper.playTap();
+            Navigator.pop(context);
+          },
           child: Text(l.t('close')),
         ),
         ElevatedButton(
-          onPressed: () => Navigator.pop(context, _phone.trim()),
+          onPressed: () {
+            SoundHelper.playTap();
+            Navigator.pop(context, _phone.trim());
+          },
           child: Text(l.t('send')),
         ),
       ],
@@ -454,6 +478,7 @@ class _EmailSentDialogState extends State<_EmailSentDialog> {
       actions: [
         ElevatedButton(
           onPressed: () {
+            SoundHelper.playTap();
             Navigator.of(context).pop();
             widget.onClose();
           },
@@ -514,6 +539,7 @@ class _SmsSentDialogState extends State<_SmsSentDialog> {
       actions: [
         ElevatedButton(
           onPressed: () {
+            SoundHelper.playTap();
             Navigator.of(context).pop();
             widget.onClose();
           },

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -7,6 +7,7 @@ import 'mowiz_page.dart';
 import 'mowiz_success_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 import 'styles/mowiz_buttons.dart';
+import 'sound_helper.dart';
 
 class MowizSummaryPage extends StatefulWidget {
   final String plate;
@@ -46,7 +47,10 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
       final selected = _method == value;
       final scheme = Theme.of(context).colorScheme;
       return FilledButton.icon(
-        onPressed: () => setState(() => _method = value),
+        onPressed: () {
+          SoundHelper.playTap();
+          setState(() => _method = value);
+        },
         icon: Icon(icon, size: fSize + 12),
         label: AutoSizeText(text, maxLines: 1),
         style: kMowizFilledButtonStyle.copyWith(
@@ -58,10 +62,10 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
       );
     }
 
-    Future<void> _pay() async {
-      if (_method == null) return;
-      // TODO: integrate real payment logic and backend communication
-      if (!mounted) return;
+  Future<void> _pay() async {
+    if (_method == null) return;
+    // TODO: integrate real payment logic and backend communication
+    if (!mounted) return;
       await Navigator.of(context).push(
         MaterialPageRoute(
           builder: (_) => MowizSuccessPage(
@@ -170,7 +174,12 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
             ),
             SizedBox(height: gap * 2),
             FilledButton(
-              onPressed: _method != null ? _pay : null,
+              onPressed: _method != null
+                  ? () {
+                      SoundHelper.playTap();
+                      _pay();
+                    }
+                  : null,
               style: kMowizFilledButtonStyle.copyWith(
                 textStyle: MaterialStatePropertyAll(
                   TextStyle(fontSize: titleFont),
@@ -181,6 +190,7 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
             SizedBox(height: gap),
             FilledButton(
               onPressed: () {
+                SoundHelper.playTap();
                 Navigator.of(context).pushAndRemoveUntil(
                   MaterialPageRoute(builder: (_) => const MowizPage()),
                   (route) => false,

--- a/lib/mowiz_time_page.dart
+++ b/lib/mowiz_time_page.dart
@@ -7,6 +7,7 @@ import 'mowiz_page.dart';
 import 'mowiz_summary_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 import 'styles/mowiz_buttons.dart';
+import 'sound_helper.dart';
 
 class MowizTimePage extends StatefulWidget {
   final String zone;
@@ -98,7 +99,10 @@ class _MowizTimePageState extends State<MowizTimePage> {
           Widget timeBtn(String text, int delta) => Expanded(
                 child: ElevatedButton(
                   style: timeButtonStyle,
-                  onPressed: () => _modifyMinutes(delta),
+                  onPressed: () {
+                    SoundHelper.playTap();
+                    _modifyMinutes(delta);
+                  },
                   child: AutoSizeText(text, maxLines: 1),
                 ),
               );
@@ -162,6 +166,7 @@ class _MowizTimePageState extends State<MowizTimePage> {
                 const Spacer(),
                 FilledButton(
                   onPressed: () {
+                    SoundHelper.playTap();
                     Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (_) => MowizSummaryPage(
@@ -183,6 +188,7 @@ class _MowizTimePageState extends State<MowizTimePage> {
                 SizedBox(height: gap),
                 FilledButton(
                   onPressed: () {
+                    SoundHelper.playTap();
                     Navigator.of(context).pushAndRemoveUntil(
                       MaterialPageRoute(builder: (_) => const MowizPage()),
                       (route) => false,

--- a/lib/sound_helper.dart
+++ b/lib/sound_helper.dart
@@ -1,0 +1,30 @@
+import 'package:audioplayers/audioplayers.dart';
+
+/// Helper para reproducir sonidos en la app.
+/// Se ha diseñado para ser fácilmente extensible con más efectos de audio.
+class SoundHelper {
+  // Constructor privado para evitar instancias
+  SoundHelper._();
+
+  /// Reproductor para el sonido de tap. Se mantiene en memoria para
+  /// reducir la latencia al pulsar un botón.
+  static final AudioPlayer _tapPlayer =
+      AudioPlayer()..setReleaseMode(ReleaseMode.stop);
+
+  /// Ruta del sonido de tap dentro de assets.
+  static const String _tapAsset = 'sound/start.mp3';
+
+  /// Reproduce el sonido de tap. Se llama al pulsar cualquier botón.
+  static Future<void> playTap() async {
+    try {
+      // Si el sonido estaba sonando, lo reiniciamos para reproducirlo de nuevo
+      await _tapPlayer.stop();
+    } catch (_) {
+      // Ignoramos cualquier error al detener
+    }
+    await _tapPlayer.play(AssetSource(_tapAsset));
+  }
+
+  // Aquí podrían añadirse métodos como `playSuccess()` o `playError()` usando
+  // otros AudioPlayer si fuese necesario en el futuro.
+}


### PR DESCRIPTION
## Summary
- introduce `SoundHelper` to centralize audio effects
- play tap sound in every button of MOWIZ pages

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874d97be988332b1980dc89f6e48a7