### PR TITLE
Add audioplayers dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Antes de ejecutar la aplicación por primera vez ejecuta:
 flutter pub get
 ```
 
-Este comando descarga todos los paquetes requeridos, como `cloud_functions_web`. Si falta esta dependencia se producirá un error parecido a:
+Este comando descarga todos los paquetes requeridos, como `cloud_functions_web` o `audioplayers`. Si falta alguna dependencia se producirá un error parecido a:
 
 ```
-Error: Couldn't resolve the package 'cloud_functions_web'
+Error: Couldn't resolve the package 'audioplayers'
 ```
 
 Ejecutar `flutter pub get` soluciona el problema.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   lottie: ^2.7.0             # Animaciones Lottie para la página de éxito
   confetti: ^0.7.0           # Animación de confeti en pantalla de éxito
   auto_size_text: ^3.0.0     # Texto escalable automaticamente
+  audioplayers: ^6.5.0       # Reproducción de efectos de sonido
 
 dev_dependencies:
   flutter_test:
@@ -41,3 +42,4 @@ flutter:
   assets:
     - assets/logo.png
     - assets/success.json
+    - assets/sound/start.mp3


### PR DESCRIPTION
## Summary
- document that `flutter pub get` fetches `audioplayers`
- add `audioplayers` package and sound asset to `pubspec.yaml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688754734d688332a121f77d37d31775