### PR TITLE
Add HTTP fetch for tariff data

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   confetti: ^0.7.0           # Animación de confeti en pantalla de éxito
   auto_size_text: ^3.0.0     # Texto escalable automaticamente
   audioplayers: ^6.5.0       # Reproducción de efectos de sonido
+  http: ^1.1.0               # Peticiones HTTP
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add http dependency
- fetch tariff data in `MowizTimePage` using `http`
- display rate steps when available

## Testing
- `dart` and `flutter` commands were unavailable so tests could not run

------
https://chatgpt.com/codex/tasks/task_e_688886bd0c508332a4c414aeaf3c3832