### PR TITLE
Optimize Mowiz pages

### DIFF
--- a/lib/mowiz/mowiz_scaffold.dart
+++ b/lib/mowiz/mowiz_scaffold.dart
@@ -14,7 +14,6 @@ class MowizScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
     // Clona el tema actual y sólo activa Material 3
     final mowizTheme = theme.copyWith(
       useMaterial3: true,

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -66,10 +66,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       TextStyle(fontSize: inputFont),
                     ),
                   ),
-                  child: AutoSizeText(
-                    text,
-                    maxLines: 1,
-                  ),
+                  child: Text(text, maxLines: 1),
                 ),
               );
 
@@ -79,7 +76,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  AutoSizeText(
+                  Text(
                     t('selectZone'),
                     maxLines: 1,
                     textAlign: TextAlign.center,
@@ -134,10 +131,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       textStyle:
                           MaterialStatePropertyAll(TextStyle(fontSize: titleFont)),
                     ),
-                    child: AutoSizeText(
-                      t('confirm'),
-                      maxLines: 1,
-                    ),
+                    child: Text(t('confirm'), maxLines: 1),
                   ),
                   SizedBox(height: gap),
                   FilledButton(
@@ -149,10 +143,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       textStyle:
                           MaterialStatePropertyAll(TextStyle(fontSize: titleFont)),
                     ),
-                    child: AutoSizeText(
-                      t('cancel'),
-                      maxLines: 1,
-                    ),
+                    child: Text(t('cancel'), maxLines: 1),
                   ),
                 ],
               ),

--- a/lib/sound_helper.dart
+++ b/lib/sound_helper.dart
@@ -27,11 +27,8 @@ class SoundHelper {
   /// Reproduce el sonido de tap. Se llama al pulsar cualquier botón.
   static Future<void> playTap() async {
     try {
-      // Si el sonido estaba sonando, lo reiniciamos para reproducirlo de nuevo
-      await _tapPlayer.stop();
-    } catch (_) {
-      // Ignoramos cualquier error al detener
-    }
+      await _tapPlayer.seek(Duration.zero);
+    } catch (_) {}
     await _tapPlayer.play(AssetSource(_tapAsset));
   }
 


### PR DESCRIPTION
## Summary
- reduce AutoSizeText usage on `MowizPayPage`
- reuse `http.Client` and avoid setState when unmounted in `MowizCancelPage`
- reuse `http.Client` and optimize tariff loading in `MowizTimePage`
- use `ListView.builder` for tariff list
- clean unused variable in `MowizScaffold`
- tweak sound helper to seek audio instead of stopping

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888e16bd92483328e943fd8bb6ea220