### PR TITLE
Centralize mock API URL

### DIFF
--- a/lib/api_config.dart
+++ b/lib/api_config.dart
@@ -1,0 +1,4 @@
+/// Global API configuration
+/// API base URL for the mock backend
+const String apiBaseUrl = "https://mock-mowiz.onrender.com"; // API base URL
+

--- a/lib/mowiz_cancel_page.dart
+++ b/lib/mowiz_cancel_page.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:http/http.dart' as http;
 
+// Base URL configuration for API calls
+import 'api_config.dart';
+
 import 'l10n/app_localizations.dart';
 import 'mowiz/mowiz_scaffold.dart';
 import 'styles/mowiz_buttons.dart';
@@ -35,8 +38,8 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
     try {
       // API call
       final res = await http.get(
-        Uri.parse(
-            'http://localhost:3000/v1/onstreet-service/validate-ticket/$plate'),
+        // Use the base URL constant here
+        Uri.parse('$apiBaseUrl/v1/onstreet-service/validate-ticket/$plate'),
       );
       if (res.statusCode == 200) {
         final data = jsonDecode(res.body);

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
+
+// Base URL configuration for API calls
+import 'api_config.dart';
 import 'dart:convert';
 
 import 'l10n/app_localizations.dart';
@@ -69,8 +72,9 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
     final plate = widget.plate.toUpperCase();
     try {
       // save paid plate
+        // Use the base URL constant here
       final res = await http.post(
-        Uri.parse('http://localhost:3000/v1/onstreet-service/pay-ticket'),
+        Uri.parse('$apiBaseUrl/v1/onstreet-service/pay-ticket'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({'plate': plate}),
       );

--- a/lib/mowiz_time_page.dart
+++ b/lib/mowiz_time_page.dart
@@ -6,6 +6,9 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
 
+// Base URL configuration for API calls
+import 'api_config.dart';
+
 import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
 import 'mowiz_summary_page.dart';
@@ -48,8 +51,9 @@ class _MowizTimePageState extends State<MowizTimePage> {
       _tariffLoaded = false;
     });
 
+    // Build the request URL using the base constant
     final url =
-        'http://localhost:3000/v1/onstreet-service/product/by-zone/${widget.zone}&plate=${widget.plate}';
+        '$apiBaseUrl/v1/onstreet-service/product/by-zone/${widget.zone}&plate=${widget.plate}';
     try {
       final res = await http.get(Uri.parse(url));
       if (res.statusCode == 200) {


### PR DESCRIPTION
## Summary
- set up `apiBaseUrl` constant
- use `apiBaseUrl` for cancel, time and summary pages

## Testing
- `grep -R "http://localhost:3000" -n lib | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6889dba5a2048332a9b02fd08553ee66