### PR TITLE
Update Mowiz navigation and labels

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -65,6 +65,7 @@ class AppLocalizations {
       'paymentError': 'Error al procesar el pago',
       // Actualizado: antes "Volver a la pantalla principal"
       'goHome': 'Cerrar',
+      'home': 'Inicio',
       'back': 'Atrás',
       'emergencyTitle': 'ADVERTENCIA',
       'autoCloseIn': 'Cierre automático en {seconds} s',
@@ -150,6 +151,7 @@ class AppLocalizations {
       'paymentError': 'Error en processar el pagament',
       // Actualitzat: abans "Tornar a l'inici"
       'goHome': 'Tancar',
+      'home': 'Inici',
       'back': 'Enrere',
       'emergencyTitle': 'Emergència',
       'autoCloseIn': 'Tancament automàtic en {seconds} s',
@@ -235,6 +237,7 @@ class AppLocalizations {
       'paymentError': 'Payment error',
       // Updated from "Return to main screen"
       'goHome': 'Close',
+      'home': 'Home',
       'back': 'Back',
       'emergencyTitle': 'Emergency',
       'autoCloseIn': 'Auto close in {seconds}s',

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -4,6 +4,7 @@ import 'theme_mode_button.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz_pay_page.dart';
 import 'mowiz_cancel_page.dart';
+import 'home_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 // Estilo de botones grandes reutilizable
 import 'styles/mowiz_buttons.dart';
@@ -17,13 +18,16 @@ class MowizPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context).t;
     return MowizScaffold(
-      title: t('mowizTitle'),
+      title: 'MeyPark',
       actions: const [
         LanguageSelector(),
         SizedBox(width: 8),
         ThemeModeButton(),
       ],
-      body: LayoutBuilder(
+      body: Column(
+        children: [
+          Expanded(
+            child: LayoutBuilder(
         // LayoutBuilder nos da el ancho disponible para calcular
         // paddings y tamaños de forma proporcional.
         builder: (context, constraints) {
@@ -131,6 +135,24 @@ class MowizPage extends StatelessWidget {
             ),
           );
         },
+        ),
+      ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 16),
+            child: TextButton(
+              onPressed: () {
+                SoundHelper.playTap();
+                Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (_) => const HomePage()),
+                  (route) => false,
+                );
+              },
+              style:
+                  TextButton.styleFrom(minimumSize: const Size.fromHeight(40)),
+              child: Text(t('home')),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -3,6 +3,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz_time_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
+import 'mowiz_page.dart';
 // Estilo común para botones grandes
 import 'styles/mowiz_buttons.dart';
 import 'sound_helper.dart';
@@ -32,7 +33,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
     final t = AppLocalizations.of(context).t;
     final colorScheme = Theme.of(context).colorScheme;
     return MowizScaffold(
-      title: t('payTicket'),
+      title: 'MeyPark - ${t('selectZone')}',
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
@@ -143,14 +144,17 @@ class _MowizPayPageState extends State<MowizPayPage> {
                   FilledButton(
                     onPressed: () {
                       SoundHelper.playTap();
-                      Navigator.of(context).pop();
+                      Navigator.of(context).pushAndRemoveUntil(
+                        MaterialPageRoute(builder: (_) => const MowizPage()),
+                        (route) => false,
+                      );
                     },
                     style: kMowizFilledButtonStyle.copyWith(
                       textStyle:
                           MaterialStatePropertyAll(TextStyle(fontSize: titleFont)),
                     ),
                     child: AutoSizeText(
-                      t('cancel'),
+                      t('back'),
                       maxLines: 1,
                     ),
                   ),

--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -339,7 +339,7 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                                 TextStyle(fontSize: titleFont - 6),
                               ),
                             ),
-                            child: AutoSizeText(t('goHome'), maxLines: 1),
+                            child: AutoSizeText(t('home'), maxLines: 1),
                           ),
                         ),
                       ),

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 
 import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
+import 'mowiz_time_page.dart';
 import 'mowiz_success_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 import 'styles/mowiz_buttons.dart';
@@ -211,7 +212,12 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
               onPressed: () {
                 SoundHelper.playTap();
                 Navigator.of(context).pushAndRemoveUntil(
-                  MaterialPageRoute(builder: (_) => const MowizPage()),
+                  MaterialPageRoute(
+                    builder: (_) => MowizTimePage(
+                      zone: widget.zone,
+                      plate: widget.plate,
+                    ),
+                  ),
                   (route) => false,
                 );
               },
@@ -223,7 +229,7 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                   TextStyle(fontSize: titleFont),
                 ),
               ),
-              child: AutoSizeText(t('cancel'), maxLines: 1),
+              child: AutoSizeText(t('back'), maxLines: 1),
             ),
           ],
         ),

--- a/lib/mowiz_time_page.dart
+++ b/lib/mowiz_time_page.dart
@@ -11,6 +11,7 @@ import 'api_config.dart';
 
 import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
+import 'mowiz_pay_page.dart';
 import 'mowiz_summary_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 import 'styles/mowiz_buttons.dart';
@@ -146,7 +147,7 @@ class _MowizTimePageState extends State<MowizTimePage> {
         );
 
     return MowizScaffold(
-      title: t('selectDuration'),
+      title: 'MeyPark - ${t('selectDuration')}',
       body: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
@@ -205,7 +206,7 @@ class _MowizTimePageState extends State<MowizTimePage> {
               onPressed: () {
                 SoundHelper.playTap();
                 Navigator.of(context).pushAndRemoveUntil(
-                  MaterialPageRoute(builder: (_) => const MowizPage()),
+                  MaterialPageRoute(builder: (_) => const MowizPayPage()),
                   (route) => false,
                 );
               },
@@ -214,7 +215,7 @@ class _MowizTimePageState extends State<MowizTimePage> {
                   Theme.of(context).colorScheme.secondary,
                 ),
               ),
-              child: AutoSizeText(t('cancel'), maxLines: 1),
+              child: AutoSizeText(t('back'), maxLines: 1),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- add new `home` translation key
- show MeyPark branding in Mowiz screens
- add `Inicio` button on Mowiz start page
- update navigation/back buttons between Mowiz pages
- fix success screen button label

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5441e4508332aaeb5159cfc10c10