### PR TITLE
Refactor Mowiz pages for responsive layout

### DIFF
--- a/lib/mowiz/mowiz_scaffold.dart
+++ b/lib/mowiz/mowiz_scaffold.dart
@@ -33,7 +33,7 @@ class MowizScaffold extends StatelessWidget {
                 title: Text(title!),
                 actions: actions,
               ),
-        body: body,
+        body: SafeArea(child: body),
       ),
     );
   }

--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'language_selector.dart';
 import 'theme_mode_button.dart';
@@ -8,7 +9,6 @@ import 'home_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
 // Estilo de botones grandes reutilizable
 import 'styles/mowiz_buttons.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'sound_helper.dart';
 
 class MowizPage extends StatelessWidget {
@@ -38,19 +38,12 @@ class MowizPage extends StatelessWidget {
           const double breakpoint = 700;
           final bool isWide = width >= breakpoint;
 
-          // Padding y separación basados en el ancho disponible. Utilizamos
-          // un porcentaje para que los botones ocupen entre el 80% y 95%
-          // del ancho sin pegarse a los bordes.
           final padding = EdgeInsets.symmetric(horizontal: width * 0.05);
-          final double gap = isWide ? 32 : 24;
+          final double gap = width * 0.05;
 
-          // Tamaño de fuente adaptativo para los botones principales
-          final double fontSize = isWide ? 28 : 24;
-
-          // Alto deseado para los botones. En orientación vertical se reduce
-          // para evitar que ocupen toda la pantalla.
-          final double buttonHeight = isWide ? 120 : 68;
-          final double buttonPadding = isWide ? 24 : 16;
+          final double fontSize = max(16, width * 0.045);
+          final double buttonHeight = max(48, width * 0.15);
+          final double buttonPadding = width * 0.03;
 
           // Estilo base para ambos botones. Las esquinas redondeadas y el
           // padding se mantienen, pero la altura mínima se ajusta según la
@@ -66,47 +59,58 @@ class MowizPage extends StatelessWidget {
                 borderRadius: BorderRadius.all(Radius.circular(30)),
               ),
             ),
-            textStyle: MaterialStatePropertyAll(
-              TextStyle(fontSize: fontSize),
+            textStyle:
+                MaterialStatePropertyAll(TextStyle(fontSize: fontSize)),
+          );
+
+          final buttonConstraints = BoxConstraints(
+            maxWidth: 400,
+            minWidth: isWide ? width * 0.4 : width * 0.9,
+            minHeight: 48,
+          );
+
+          final payBtn = ConstrainedBox(
+            constraints: buttonConstraints,
+            child: FilledButton(
+              onPressed: () {
+                SoundHelper.playTap();
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const MowizPayPage(),
+                  ),
+                );
+              },
+              style: baseStyle,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(t('payTicket')),
+              ),
             ),
           );
 
-          final payBtn = FilledButton(
-            onPressed: () {
-              SoundHelper.playTap();
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const MowizPayPage(),
+          final cancelBtn = ConstrainedBox(
+            constraints: buttonConstraints,
+            child: FilledButton(
+              onPressed: () {
+                SoundHelper.playTap();
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const MowizCancelPage(),
+                  ),
+                );
+              },
+              style: baseStyle.copyWith(
+                backgroundColor: MaterialStatePropertyAll(
+                  Theme.of(context).colorScheme.secondary,
                 ),
-              );
-            },
-            style: baseStyle,
-            child: AutoSizeText(
-              t('payTicket'),
-              maxLines: 1,
-            ),
-          );
-
-          final cancelBtn = FilledButton(
-            onPressed: () {
-              SoundHelper.playTap();
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const MowizCancelPage(),
+                foregroundColor: MaterialStatePropertyAll(
+                  Theme.of(context).colorScheme.onSecondary,
                 ),
-              );
-            },
-            style: baseStyle.copyWith(
-              backgroundColor: MaterialStatePropertyAll(
-                Theme.of(context).colorScheme.secondary,
               ),
-              foregroundColor: MaterialStatePropertyAll(
-                Theme.of(context).colorScheme.onSecondary,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(t('cancelDenuncia')),
               ),
-            ),
-            child: AutoSizeText(
-              t('cancelDenuncia'),
-              maxLines: 1,
             ),
           );
 

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -1,5 +1,5 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz_time_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
@@ -37,20 +37,15 @@ class _MowizPayPageState extends State<MowizPayPage> {
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          final isLargeTablet = width >= 900;
-          final isTablet = width >= 600 && width < 900;
           final padding = EdgeInsets.all(width * 0.05);
-          final double gap = width * 0.04;
-          final double titleFont = isLargeTablet
-              ? 32
-              : isTablet
-                  ? 28
-                  : 24;
-          final double inputFont = isLargeTablet
-              ? 28
-              : isTablet
-                  ? 24
-                  : 20;
+          final double gap = width * 0.05;
+          final double titleFont = max(16, width * 0.05);
+          final double inputFont = max(16, width * 0.045);
+          final buttonConstraints = BoxConstraints(
+            maxWidth: 400,
+            minWidth: width * 0.9,
+            minHeight: 48,
+          );
 
           final zoneButton = (String value, String text, Color color) =>
               Expanded(
@@ -63,30 +58,31 @@ class _MowizPayPageState extends State<MowizPayPage> {
                     backgroundColor: MaterialStatePropertyAll(
                       _selectedZone == value ? color : colorScheme.secondary,
                     ),
-                    textStyle: MaterialStatePropertyAll(
-                      TextStyle(fontSize: inputFont),
-                    ),
+                    textStyle:
+                        MaterialStatePropertyAll(TextStyle(fontSize: inputFont)),
                   ),
-                  child: AutoSizeText(
-                    text,
-                    maxLines: 1,
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(text),
                   ),
                 ),
               );
 
           return Padding(
             padding: padding,
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  AutoSizeText(
-                    t('selectZone'),
-                    maxLines: 1,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: titleFont,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                  FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      t('selectZone'),
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: titleFont,
+                      ),
                     ),
                   ),
                   SizedBox(height: gap),
@@ -117,7 +113,9 @@ class _MowizPayPageState extends State<MowizPayPage> {
                     onChanged: (_) => setState(() {}),
                   ),
                   SizedBox(height: gap * 1.5),
-                  FilledButton(
+                  ConstrainedBox(
+                    constraints: buttonConstraints,
+                    child: FilledButton(
                     onPressed: _confirmEnabled
                         ? () {
                             SoundHelper.playTap();
@@ -135,13 +133,15 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       textStyle:
                           MaterialStatePropertyAll(TextStyle(fontSize: titleFont)),
                     ),
-                    child: AutoSizeText(
-                      t('confirm'),
-                      maxLines: 1,
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(t('confirm')),
                     ),
                   ),
                   SizedBox(height: gap),
-                  FilledButton(
+                  ConstrainedBox(
+                    constraints: buttonConstraints,
+                    child: FilledButton(
                     onPressed: () {
                       SoundHelper.playTap();
                       Navigator.of(context).pushAndRemoveUntil(
@@ -153,9 +153,9 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       textStyle:
                           MaterialStatePropertyAll(TextStyle(fontSize: titleFont)),
                     ),
-                    child: AutoSizeText(
-                      t('back'),
-                      maxLines: 1,
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(t('back')),
                     ),
                   ),
                 ],

--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
+import 'dart:math';
 import 'package:flutter/material.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:intl/intl.dart';
 import 'package:lottie/lottie.dart';
 import 'package:qr_flutter/qr_flutter.dart';
@@ -154,15 +154,9 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          final isLargeTablet = width >= 900;
-          final isTablet = width >= 600 && width < 900;
           final padding = EdgeInsets.all(width * 0.05);
-          final double gap = width * 0.04;
-          final double titleFont = isLargeTablet
-              ? 32
-              : isTablet
-                  ? 28
-                  : 24;
+          final double gap = width * 0.05;
+          final double titleFont = max(16, width * 0.05);
           final double qrSize = width * 0.4;
 
           return Stack(
@@ -175,10 +169,11 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                   shouldLoop: false,
                 ),
               ),
-              SingleChildScrollView(
+              Padding(
                 padding: padding,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
                     Lottie.asset(
                       'assets/success.json',
@@ -186,13 +181,15 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                       repeat: false,
                     ),
                     SizedBox(height: gap / 2),
-                    AutoSizeText(
-                      t('paymentSuccess'),
-                      maxLines: 1,
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: titleFont,
-                        fontWeight: FontWeight.bold,
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        t('paymentSuccess'),
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: titleFont,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                     ),
                     SizedBox(height: gap / 2),
@@ -219,46 +216,60 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      AutoSizeText(
-                        t('ticketSummary'),
-                        maxLines: 1,
-                        style: TextStyle(
-                          fontSize: titleFont - 6,
-                          fontWeight: FontWeight.bold,
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          t('ticketSummary'),
+                          style: TextStyle(
+                            fontSize: titleFont - 6,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
-                      AutoSizeText(
-                        "${t('plate')}: ${widget.plate}",
-                        maxLines: 1,
-                        style: TextStyle(fontSize: titleFont - 8),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          "${t('plate')}: ${widget.plate}",
+                          style: TextStyle(fontSize: titleFont - 8),
+                        ),
                       ),
-                      AutoSizeText(
-                        // i18n zone name
-                        "${t('zone')}: ${widget.zone == 'green' ? t('zoneGreen') : t('zoneBlue')}",
-                        maxLines: 1,
-                        style: TextStyle(fontSize: titleFont - 8),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          // i18n zone name
+                          "${t('zone')}: ${widget.zone == 'green' ? t('zoneGreen') : t('zoneBlue')}",
+                          style: TextStyle(fontSize: titleFont - 8),
+                        ),
                       ),
-                      AutoSizeText(
-                        "${t('startTime')}: ${timeFormat.format(widget.start)}",
-                        maxLines: 1,
-                        style: TextStyle(fontSize: titleFont - 8),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          "${t('startTime')}: ${timeFormat.format(widget.start)}",
+                          style: TextStyle(fontSize: titleFont - 8),
+                        ),
                       ),
-                      AutoSizeText(
-                        "${t('endTime')}: ${timeFormat.format(finish)}",
-                        maxLines: 1,
-                        style: TextStyle(fontSize: titleFont - 8),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          "${t('endTime')}: ${timeFormat.format(finish)}",
+                          style: TextStyle(fontSize: titleFont - 8),
+                        ),
                       ),
-                      AutoSizeText(
-                        // i18n price format
-                        "${t('totalPrice')}: ${currencyFormat.format(widget.price)}",
-                        maxLines: 1,
-                        style: TextStyle(fontSize: titleFont - 8),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          // i18n price format
+                          "${t('totalPrice')}: ${currencyFormat.format(widget.price)}",
+                          style: TextStyle(fontSize: titleFont - 8),
+                        ),
                       ),
-                      AutoSizeText(
-                        // i18n payment method
-                        "${t('paymentMethod')}: ${methodMap[widget.method] ?? widget.method}",
-                        maxLines: 1,
-                        style: TextStyle(fontSize: titleFont - 8),
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          // i18n payment method
+                          "${t('paymentMethod')}: ${methodMap[widget.method] ?? widget.method}",
+                          style: TextStyle(fontSize: titleFont - 8),
+                        ),
                       ),
                     ],
                   ),
@@ -283,7 +294,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                                 TextStyle(fontSize: titleFont - 6),
                               ),
                             ),
-                            child: AutoSizeText(t('printTicket'), maxLines: 1),
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(t('printTicket')),
+                            ),
                           ),
                         ),
                       ),
@@ -300,7 +314,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                                 TextStyle(fontSize: titleFont - 6),
                               ),
                             ),
-                            child: AutoSizeText(t('sendBySms'), maxLines: 1),
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(t('sendBySms')),
+                            ),
                           ),
                         ),
                       ),
@@ -322,7 +339,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                                 TextStyle(fontSize: titleFont - 6),
                               ),
                             ),
-                            child: AutoSizeText(t('sendByEmail'), maxLines: 1),
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(t('sendByEmail')),
+                            ),
                           ),
                         ),
                       ),
@@ -339,7 +359,10 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                                 TextStyle(fontSize: titleFont - 6),
                               ),
                             ),
-                            child: AutoSizeText(t('home'), maxLines: 1),
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              child: Text(t('home')),
+                            ),
                           ),
                         ),
                       ),
@@ -348,11 +371,13 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
               ],
             ),
             SizedBox(height: gap * 1.5),
-            AutoSizeText(
-              t('returningIn', params: {'seconds': '$_seconds'}),
-              maxLines: 1,
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: titleFont - 6),
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                t('returningIn', params: {'seconds': '$_seconds'}),
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: titleFont - 6),
+              ),
             ),
             ],
           ),

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -1,5 +1,5 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
 
@@ -82,18 +82,24 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
     Widget paymentButton(String value, IconData icon, String text, double fSize) {
       final selected = _method == value;
       final scheme = Theme.of(context).colorScheme;
-      return FilledButton.icon(
-        onPressed: () async {
-          SoundHelper.playTap();
-          setState(() => _method = value);
-          await _pay();
-        },
-        icon: Icon(icon, size: fSize + 12),
-        label: AutoSizeText(text, maxLines: 1),
-        style: kMowizFilledButtonStyle.copyWith(
-          textStyle: MaterialStatePropertyAll(TextStyle(fontSize: fSize)),
-          backgroundColor: MaterialStatePropertyAll(
-            selected ? scheme.primary : scheme.secondary,
+      return ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400, minHeight: 48),
+        child: FilledButton.icon(
+          onPressed: () async {
+            SoundHelper.playTap();
+            setState(() => _method = value);
+            await _pay();
+          },
+          icon: Icon(icon, size: fSize + 12),
+          label: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(text),
+          ),
+          style: kMowizFilledButtonStyle.copyWith(
+            textStyle: MaterialStatePropertyAll(TextStyle(fontSize: fSize)),
+            backgroundColor: MaterialStatePropertyAll(
+              selected ? scheme.primary : scheme.secondary,
+            ),
           ),
         ),
       );
@@ -104,22 +110,16 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          final isLargeTablet = width >= 900;
-          final isTablet = width >= 600 && width < 900;
           final padding = EdgeInsets.all(width * 0.05);
-          final double gap = width * 0.04;
-          final double titleFont = isLargeTablet
-              ? 32
-              : isTablet
-                  ? 28
-                  : 24;
+          final double gap = width * 0.05;
+          final double titleFont = max(16, width * 0.05);
 
           return Padding(
             padding: padding,
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
             // Cuadro con la información resumida del ticket.
             // Se deja crecer de forma dinámica y con scroll interno
             // para evitar cualquier overflow si hay mucho texto.
@@ -130,44 +130,53 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
               elevation: 4,
               child: Padding(
                 padding: const EdgeInsets.all(24),
-                child: SingleChildScrollView(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                    AutoSizeText(
-                      t('totalTime'),
-                      maxLines: 1,
-                      style: TextStyle(
-                        fontSize: titleFont - 4,
-                        fontWeight: FontWeight.bold,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        t('totalTime'),
+                        style: TextStyle(
+                          fontSize: titleFont - 4,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                     ),
                     const SizedBox(height: 8),
-                    AutoSizeText(
-                      '${widget.minutes ~/ 60}h ${widget.minutes % 60}m',
-                      maxLines: 1,
-                      style: TextStyle(fontSize: titleFont + 8),
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        '${widget.minutes ~/ 60}h ${widget.minutes % 60}m',
+                        style: TextStyle(fontSize: titleFont + 8),
+                      ),
                     ),
                     const SizedBox(height: 16),
-                    AutoSizeText(
-                      "${t('startTime')}: ${timeFormat.format(widget.start)}",
-                      maxLines: 1,
-                      style: TextStyle(fontSize: titleFont - 4),
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        "${t('startTime')}: ${timeFormat.format(widget.start)}",
+                        style: TextStyle(fontSize: titleFont - 4),
+                      ),
                     ),
                     const SizedBox(height: 8),
-                    AutoSizeText(
-                      "${t('endTime')}: ${timeFormat.format(finish)}",
-                      maxLines: 1,
-                      style: TextStyle(fontSize: titleFont - 4),
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        "${t('endTime')}: ${timeFormat.format(finish)}",
+                        style: TextStyle(fontSize: titleFont - 4),
+                      ),
                     ),
                     const SizedBox(height: 16),
-                    AutoSizeText(
-                      "${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €",
-                      maxLines: 1,
-                      style: TextStyle(
-                        fontSize: titleFont,
-                        fontWeight: FontWeight.bold,
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
+                        "${t('totalPrice')}: ${widget.price.toStringAsFixed(2)} €",
+                        style: TextStyle(
+                          fontSize: titleFont,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                     ),
                   ],
@@ -192,7 +201,9 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                   paymentButton('mobile', Icons.phone_iphone, t('mobilePay'), titleFont),
             ),
             SizedBox(height: gap * 2),
-            FilledButton(
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400, minHeight: 48),
+              child: FilledButton(
               onPressed: () {
                 SoundHelper.playTap();
                 Navigator.of(context).pushAndRemoveUntil(
@@ -213,7 +224,11 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                   TextStyle(fontSize: titleFont),
                 ),
               ),
-              child: AutoSizeText(t('back'), maxLines: 1),
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(t('back')),
+              ),
+            ),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- wrap MowizScaffold body with SafeArea
- refactor all Mowiz pages to use LayoutBuilder/MediaQuery
- replace AutoSizeText with FittedBox and Text
- remove scroll views and add width constraints for buttons

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6803330c833297b03e493a30cc4f