### PR TITLE
Fix bracket issues in Mowiz pages

### DIFF
--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -138,6 +138,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       child: Text(t('confirm')),
                     ),
                   ),
+                  ),
                   SizedBox(height: gap),
                   ConstrainedBox(
                     constraints: buttonConstraints,
@@ -157,6 +158,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       fit: BoxFit.scaleDown,
                       child: Text(t('back')),
                     ),
+                  ),
                   ),
                 ],
               ),

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -183,7 +183,6 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                 ),
               ),
             ),
-            ),
             SizedBox(height: gap * 2),
             Padding(
               padding: EdgeInsets.symmetric(horizontal: width * 0.1),


### PR DESCRIPTION
## Summary
- remove stray parenthesis in `MowizSummaryPage`
- close `ConstrainedBox` in `MowizPayPage`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a6c803a508332bfdb6ded3c12e85a