### PR TITLE
Fix closing parentheses in widget trees

### DIFF
--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -162,7 +162,6 @@ class _MowizPayPageState extends State<MowizPayPage> {
                   ),
                 ],
               ),
-            ),
           );
         },
       ),

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -231,7 +231,6 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
             ),
           ],
         ),
-        ),
       );
         },
       ),


### PR DESCRIPTION
## Summary
- remove extra closing parenthesis from `MowizPayPage`
- remove extra closing parenthesis from `MowizSummaryPage`

## Testing
- `apt-get update`
- *(tests could not run: Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a740da29c8332b4f4b62196fc751e