### PR TITLE
Fix button width constraints

### DIFF
--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -32,6 +32,8 @@ class MowizPage extends StatelessWidget {
         // paddings y tamaños de forma proporcional.
         builder: (context, constraints) {
           final width = constraints.maxWidth;
+          final screenWidth = MediaQuery.of(context).size.width;
+          final double buttonWidth = min(screenWidth * 0.9, 400);
 
           // Punto de quiebre para pantallas anchas. Modifica este valor si
           // necesitas cambiar la responsividad de la página.
@@ -64,8 +66,8 @@ class MowizPage extends StatelessWidget {
           );
 
           final buttonConstraints = BoxConstraints(
-            maxWidth: 400,
-            minWidth: isWide ? width * 0.4 : width * 0.9,
+            maxWidth: buttonWidth,
+            minWidth: min(isWide ? screenWidth * 0.4 : screenWidth * 0.9, buttonWidth),
             minHeight: 48,
           );
 

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -37,13 +37,15 @@ class _MowizPayPageState extends State<MowizPayPage> {
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
+          final screenWidth = MediaQuery.of(context).size.width;
+          final double buttonWidth = min(screenWidth * 0.9, 400);
           final padding = EdgeInsets.all(width * 0.05);
           final double gap = width * 0.05;
           final double titleFont = max(16, width * 0.05);
           final double inputFont = max(16, width * 0.045);
           final buttonConstraints = BoxConstraints(
-            maxWidth: 400,
-            minWidth: width * 0.9,
+            maxWidth: buttonWidth,
+            minWidth: min(screenWidth * 0.9, buttonWidth),
             minHeight: 48,
           );
 


### PR DESCRIPTION
## Summary
- ensure button minWidth never exceeds maxWidth in Mowiz screens

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a79cc33f883328afd15cb46a81e1f