### PR TITLE
Fix layout overflow issues

### DIFF
--- a/lib/mowiz_page.dart
+++ b/lib/mowiz_page.dart
@@ -32,6 +32,7 @@ class MowizPage extends StatelessWidget {
         // paddings y tamaños de forma proporcional.
         builder: (context, constraints) {
           final width = constraints.maxWidth;
+          final height = constraints.maxHeight;
           final screenWidth = MediaQuery.of(context).size.width;
           final double buttonWidth = min(screenWidth * 0.9, 400);
 
@@ -40,8 +41,11 @@ class MowizPage extends StatelessWidget {
           const double breakpoint = 700;
           final bool isWide = width >= breakpoint;
 
-          final padding = EdgeInsets.symmetric(horizontal: width * 0.05);
-          final double gap = width * 0.05;
+          final padding = EdgeInsets.symmetric(
+            horizontal: width * 0.05,
+            vertical: height * 0.05,
+          );
+          final double gap = height * 0.05;
 
           final double fontSize = max(16, width * 0.045);
           final double buttonHeight = max(48, width * 0.15);
@@ -144,7 +148,10 @@ class MowizPage extends StatelessWidget {
         ),
       ),
           Padding(
-            padding: const EdgeInsets.only(bottom: 16),
+            // Espacio inferior proporcional
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).size.height * 0.02,
+            ),
             child: TextButton(
               onPressed: () {
                 SoundHelper.playTap();

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -34,13 +34,18 @@ class _MowizPayPageState extends State<MowizPayPage> {
     final colorScheme = Theme.of(context).colorScheme;
     return MowizScaffold(
       title: 'MeyPark - ${t('selectZone')}',
+      // SafeArea ya aplicada en MowizScaffold
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
+          final height = constraints.maxHeight;
           final screenWidth = MediaQuery.of(context).size.width;
           final double buttonWidth = min(screenWidth * 0.9, 400);
-          final padding = EdgeInsets.all(width * 0.05);
-          final double gap = width * 0.05;
+          final padding = EdgeInsets.symmetric(
+            horizontal: width * 0.05,
+            vertical: height * 0.05,
+          );
+          final double gap = height * 0.05;
           final double titleFont = max(16, width * 0.05);
           final double inputFont = max(16, width * 0.045);
           final buttonConstraints = BoxConstraints(
@@ -74,12 +79,12 @@ class _MowizPayPageState extends State<MowizPayPage> {
             padding: padding,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
-                  FittedBox(
-                    fit: BoxFit.scaleDown,
-                    child: Text(
-                      t('selectZone'),
+                const Spacer(),
+                FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Text(
+                    t('selectZone'),
                       textAlign: TextAlign.center,
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
@@ -87,9 +92,9 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       ),
                     ),
                   ),
-                  SizedBox(height: gap),
-                  Row(
-                    children: [
+                SizedBox(height: gap),
+                Row(
+                  children: [
                       zoneButton(
                         'blue',
                         t('zoneBlue'),
@@ -103,8 +108,8 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       ),
                     ],
                   ),
-                  SizedBox(height: gap),
-                  TextField(
+                SizedBox(height: gap),
+                TextField(
                     controller: _plateCtrl,
                     enabled: _selectedZone != null,
                     decoration: InputDecoration(
@@ -114,8 +119,8 @@ class _MowizPayPageState extends State<MowizPayPage> {
                     style: TextStyle(fontSize: inputFont),
                     onChanged: (_) => setState(() {}),
                   ),
-                  SizedBox(height: gap * 1.5),
-                  ConstrainedBox(
+                SizedBox(height: gap * 1.5),
+                ConstrainedBox(
                     constraints: buttonConstraints,
                     child: FilledButton(
                     onPressed: _confirmEnabled
@@ -141,8 +146,8 @@ class _MowizPayPageState extends State<MowizPayPage> {
                     ),
                   ),
                   ),
-                  SizedBox(height: gap),
-                  ConstrainedBox(
+                SizedBox(height: gap),
+                ConstrainedBox(
                     constraints: buttonConstraints,
                     child: FilledButton(
                     onPressed: () {
@@ -161,9 +166,10 @@ class _MowizPayPageState extends State<MowizPayPage> {
                       child: Text(t('back')),
                     ),
                   ),
-                  ),
-                ],
-              ),
+                ),
+                const Spacer(),
+              ],
+            ),
           );
         },
       ),

--- a/lib/mowiz_success_page.dart
+++ b/lib/mowiz_success_page.dart
@@ -151,11 +151,13 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return MowizScaffold(
+      // SafeArea aplicada en MowizScaffold
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          final padding = EdgeInsets.all(width * 0.05);
-          final double gap = width * 0.05;
+          final height = constraints.maxHeight;
+          final padding = EdgeInsets.all(height * 0.05);
+          final double gap = height * 0.05;
           final double titleFont = max(16, width * 0.05);
           final double qrSize = width * 0.4;
 
@@ -173,7 +175,7 @@ class _MowizSuccessPageState extends State<MowizSuccessPage> {
                 padding: padding,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   children: [
                     Lottie.asset(
                       'assets/success.json',

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -107,11 +107,13 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
 
     return MowizScaffold(
       title: t('summaryPay'),
+      // SafeArea ya aplicada en MowizScaffold
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          final padding = EdgeInsets.all(width * 0.05);
-          final double gap = width * 0.05;
+          final height = constraints.maxHeight;
+          final padding = EdgeInsets.all(height * 0.05);
+          final double gap = height * 0.05;
           final double titleFont = max(16, width * 0.05);
 
           return Padding(
@@ -123,17 +125,18 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
             // Cuadro con la información resumida del ticket.
             // Se deja crecer de forma dinámica y con scroll interno
             // para evitar cualquier overflow si hay mucho texto.
-            Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(24),
-              ),
-              elevation: 4,
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
+            Expanded(
+              child: Card(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                elevation: 4,
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
                     FittedBox(
                       fit: BoxFit.scaleDown,
                       child: Text(
@@ -182,6 +185,7 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
                   ],
                 ),
               ),
+            ),
             ),
             SizedBox(height: gap * 2),
             Padding(

--- a/lib/mowiz_time_page.dart
+++ b/lib/mowiz_time_page.dart
@@ -156,11 +156,13 @@ class _MowizTimePageState extends State<MowizTimePage> {
 
     return MowizScaffold(
       title: 'MeyPark - ${t('selectDuration')}',
+      // SafeArea ya aplicada en MowizScaffold
       body: LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-          final padding = EdgeInsets.all(width * 0.05);
-          final double gap = width * 0.05;
+          final height = constraints.maxHeight;
+          final padding = EdgeInsets.all(height * 0.05);
+          final double gap = height * 0.05;
           final double titleFont = max(16, width * 0.05);
           final double valueFont = max(16, width * 0.06);
 
@@ -170,7 +172,7 @@ class _MowizTimePageState extends State<MowizTimePage> {
             padding: padding,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 FittedBox(
                   fit: BoxFit.scaleDown,
@@ -200,7 +202,12 @@ class _MowizTimePageState extends State<MowizTimePage> {
                       textAlign: TextAlign.center,
                       style: TextStyle(fontSize: titleFont, fontWeight: FontWeight.bold)),
                 ),
-                if (_tariffLoaded) _TariffList(_stepsMap, font: titleFont) else const CircularProgressIndicator(),
+                if (_tariffLoaded)
+                  Expanded(
+                    child: _TariffList(_stepsMap, font: titleFont),
+                  )
+                else
+                  const CircularProgressIndicator(),
                 ConstrainedBox(
                   constraints: const BoxConstraints(maxWidth: 400, minHeight: 48),
                   child: FilledButton(


### PR DESCRIPTION
## Summary
- update zone selection layout
- tweak padding and spacing for Mowiz home
- adjust duration screen layout logic
- make summary screen responsive
- refine success page layout

## Testing
- `flutter --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688a88bfd1708332a07b9c905ca8677a