### PR TITLE
Implement dynamic API base URL

### DIFF
--- a/lib/api_config.dart
+++ b/lib/api_config.dart
@@ -1,4 +1,4 @@
 /// Global API configuration
-/// API base URL for the mock backend
-const String apiBaseUrl = "https://tariff2.onrender.com"; // API base URL
+/// Default API base URL for the mock backend
+const String defaultApiBaseUrl = 'https://tariff2.onrender.com';
 

--- a/lib/config_service.dart
+++ b/lib/config_service.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import 'api_config.dart';
+
+/// Service that loads configuration from the backend at runtime.
+class ConfigService {
+  /// The API base URL currently in use.
+  static String apiBaseUrl = defaultApiBaseUrl;
+
+  /// Initializes the service by requesting `/v1/config` from
+  /// [defaultApiBaseUrl]. If the request succeeds and returns a JSON
+  /// object with the `apiBaseUrl` field, the value is stored and used by
+  /// the app.
+  static Future<void> init() async {
+    try {
+      final uri = Uri.parse('${defaultApiBaseUrl}/v1/config');
+      final res =
+          await http.get(uri).timeout(const Duration(seconds: 5));
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body) as Map<String, dynamic>;
+        final url = data['apiBaseUrl'];
+        if (url is String && url.isNotEmpty) {
+          apiBaseUrl = url;
+        }
+      }
+    } catch (_) {
+      // Ignore errors and keep the default base URL
+    }
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'firebase_options.dart';
 import 'home_page.dart';
+import 'config_service.dart';
 import 'l10n/app_localizations.dart';
 import 'locale_provider.dart';
 import 'theme_provider.dart';
@@ -16,6 +17,8 @@ Future<void> main() async {
   await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
   ]);
+
+  await ConfigService.init();
 
   try {
     await Firebase.initializeApp(

--- a/lib/mowiz_cancel_page.dart
+++ b/lib/mowiz_cancel_page.dart
@@ -4,7 +4,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:http/http.dart' as http;
 
 // Base URL configuration for API calls
-import 'api_config.dart';
+import 'config_service.dart';
 
 import 'l10n/app_localizations.dart';
 import 'mowiz/mowiz_scaffold.dart';
@@ -39,7 +39,7 @@ class _MowizCancelPageState extends State<MowizCancelPage> {
       // API call
       final res = await http.get(
         // Use the base URL constant here
-        Uri.parse('$apiBaseUrl/v1/onstreet-service/validate-ticket/$plate'),
+        Uri.parse('${ConfigService.apiBaseUrl}/v1/onstreet-service/validate-ticket/$plate'),
       );
       if (res.statusCode == 200) {
         final data = jsonDecode(res.body);

--- a/lib/mowiz_pay_page.dart
+++ b/lib/mowiz_pay_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:http/http.dart' as http;
 
-import 'api_config.dart';
+import 'config_service.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz_time_page.dart';
 import 'mowiz/mowiz_scaffold.dart';
@@ -47,7 +47,7 @@ class _MowizPayPageState extends State<MowizPayPage> {
     });
     try {
       final res = await http.get(
-        Uri.parse('$apiBaseUrl/v1/onstreet-service/zones'),
+        Uri.parse('${ConfigService.apiBaseUrl}/v1/onstreet-service/zones'),
       );
       if (res.statusCode == 200) {
         final data = jsonDecode(res.body) as List;

--- a/lib/mowiz_summary_page.dart
+++ b/lib/mowiz_summary_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
-import 'api_config.dart';
+import 'config_service.dart';
 import 'dart:convert';
 
 import 'l10n/app_localizations.dart';
@@ -40,7 +40,7 @@ class _MowizSummaryPageState extends State<MowizSummaryPage> {
     final plate = widget.plate.toUpperCase();
     try {
       final res = await http.post(
-        Uri.parse('$apiBaseUrl/v1/onstreet-service/pay-ticket'),
+        Uri.parse('${ConfigService.apiBaseUrl}/v1/onstreet-service/pay-ticket'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({'plate': plate}),
       );

--- a/lib/mowiz_time_page.dart
+++ b/lib/mowiz_time_page.dart
@@ -7,7 +7,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:intl/intl.dart';
 import 'package:http/http.dart' as http;
 
-import 'api_config.dart';
+import 'config_service.dart';
 import 'l10n/app_localizations.dart';
 import 'mowiz_page.dart';
 import 'mowiz_pay_page.dart';
@@ -58,7 +58,7 @@ class _MowizTimePageState extends State<MowizTimePage> {
     });
 
     final url =
-        '$apiBaseUrl/v1/onstreet-service/product/by-zone/${widget.zone}&plate=${widget.plate}';
+        '${ConfigService.apiBaseUrl}/v1/onstreet-service/product/by-zone/${widget.zone}&plate=${widget.plate}';
     try {
       final res = await http.get(Uri.parse(url));
       if (res.statusCode == 200) {


### PR DESCRIPTION
## Summary
- add `ConfigService` for loading API base URL from `/v1/config`
- call `ConfigService.init()` on startup
- use `ConfigService.apiBaseUrl` for all HTTP requests
- define `defaultApiBaseUrl` in `api_config.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b865602fc8332a2a4e3c65701111c